### PR TITLE
Add LTS 22 build-constraints

### DIFF
--- a/build-constraints/lts-22-build-constraints.yaml
+++ b/build-constraints/lts-22-build-constraints.yaml
@@ -1,0 +1,9495 @@
+ghc-major-version: "9.6"
+# new curator is supposed to use exact GHC version
+ghc-version: "9.6.3"
+
+# This affects which version of the Cabal file format we allow. We
+# should ensure that this is always no greater than the version
+# supported by the most recent cabal-install and Stack releases.
+cabal-format-version: "3.0"
+
+# Constraints for brand new builds
+packages:
+
+    "Dominick Samperi <djsamperi@gmail.com> @djsamperi":
+        - mathlist ^>= 0.2.0.0
+
+    "Alexey Tochin <Alexey.Tochin@gmail.com> @alexeytochin":
+        - simple-expr ^>= 0.1.1.0
+        - inf-backprop ^>= 0.1.0.2
+
+    "Felix Springer <felixspringer149@gmail.com> @jumper149":
+        - deriving-trans ^>= 0.9.1.0
+        - monad-control-identity ^>= 0.2.0.0
+        - wai-control ^>= 0.2.0.0
+
+    "Eric Schorn <eric.schorn@nccgroup.com> @eric-schorn":
+        - pasta-curves < 0
+
+    "Martin Bednar <bednam17@fit.cvut.cz> @martin-bednar":
+        - wai-middleware-bearer ^>= 1.0.3
+
+    "Xy Ren <xy.r@outlook.com> @re-xyr":
+        - cleff ^>= 0.3.3.0
+        - cleff-plugin < 0
+        - rec-smallarray < 0
+
+    "Janus Troelsen <ysangkok@gmail.com> @ysangkok":
+        - ListZipper ^>= 1.2.0.2
+        - timezone-olson-th ^>= 0.1.0.11
+
+    "Paul Burns <paul@flipstone.com> @onslaughtq":
+        - rollbar ^>= 1.1.3
+
+    "David Burkett <david@davidburkett.xyz> @Disco-Dave":
+        - katip-wai ^>= 0.1.2.2
+
+    "Lukas Epple <sternenseemann@systemli.org> @sternenseemann":
+        - socket ^>= 0.8.3.0
+        - spacecookie ^>= 1.0.0.2
+        - gopher-proxy ^>= 0.1.1.3
+        - filepath-bytestring ^>= 1.4.2.1.13
+        - download-curl ^>= 0.1.4
+        - cabal2nix ^>= 2.19.1
+        - distribution-nixpkgs ^>= 1.7.0.1
+        - hackage-db ^>= 2.1.3
+        - language-nix ^>= 2.2.0
+        - jailbreak-cabal ^>= 1.4
+
+    "Profpatsch <mail@profpatsch.de> @Profpatsch":
+        - error ^>= 1.0.0.0
+        - yarn-lock ^>= 0.6.5
+
+    "James Sully <sullyj3@gmail.com> @sullyj3":
+        - buttplug-hs-core < 0
+
+    "Manuel Schneckenreither <manuel.schnecki@gmail.com> @schnecki":
+        - easy-logger ^>= 0.1.0.7
+        - welford-online-mean-variance ^>= 0.2.0.0
+
+    "Kamil Dworakowski <kamil@dworakowski.name> @luntain":
+        - error-or ^>= 0.3.0
+        - error-or-utils ^>= 0.2.0
+        - inbox ^>= 0.2.0
+
+    "Liang-Ting Chen<liang.ting.chen.tw@gmail.com> @L-TChen":
+        - geniplate-mirror < 0
+
+    "Andreas Abel <andreas.abel@gu.se> @andreasabel":
+        - Agda ^>= 2.6.4.1
+        - agda2lagda ^>= 0.2023.6.9
+        - BNFC ^>= 2.9.5
+        - cabal-clean ^>= 0.2.20230609
+        - fix-whitespace ^>= 0.1
+        - goldplate ^>= 0.2.1.1
+        - hackage-cli ^>= 0.1.0.1
+        - hasktags ^>= 0.73.0
+        - hs-tags < 0
+        - java-adt ^>= 1.0.20231204
+        - Sit ^>= 0.2023.8.3
+
+        - alex ^>= 3.4.0.1
+        - happy ^>= 1.20.1.1 && (<1.21.0 || >1.21.0)
+        - haskell-src ^>= 1.0.4
+        - ListLike ^>= 4.7.8.2
+        - MissingH ^>= 1.6.0.1
+        - regex-base ^>= 0.94.0.2
+        - regex-compat ^>= 0.95.2.1
+        - regex-pcre ^>= 0.95.0.0
+        - regex-posix ^>= 0.96.0.1
+        - regex-posix-clib ^>= 2.7
+        - regex-tdfa ^>= 1.3.2.2
+        - shelly ^>= 1.12.1
+        - STMonadTrans ^>= 0.4.7
+        - tasty-silver ^>= 3.3.1.3
+        - acid-state ^>= 0.16.1.3
+        - rss ^>= 3000.2.0.7
+        - brotli ^>= 0.0.0.1
+        - brotli-streams ^>= 0.0.0.0
+        - xor ^>= 0.0.1.2
+        - http-io-streams ^>= 0.1.6.3
+        - github ^>= 0.29
+        - microaeson ^>= 0.1.0.1
+        - cassava ^>= 0.5.3.0
+        - ini ^>= 0.4.2
+        - cryptohash-md5 ^>= 0.11.101.0
+        - cryptohash-sha1 ^>= 0.11.101.0
+        - cryptohash-sha256 ^>= 0.11.102.1
+        - cryptohash-sha512 ^>= 0.11.102.0
+        - newtype ^>= 0.2.2.0
+        - resolv ^>= 0.2.0.2
+        - blaze-builder ^>= 0.4.2.3
+        - netrc ^>= 0.2.0.0
+        - equivalence ^>= 0.4.1
+
+        # Some "grandfathered dependencies" I took over because I contributed to them at some time.
+        # Feel free to snatch them from me!
+        - regex-pcre-builtin ^>= 0.95.2.3.8.44
+        - test-framework ^>= 0.8.2.0
+        - c2hs ^>= 0.28.8
+        - cabal-doctest ^>= 1.0.9
+        - hackage-security ^>= 0.6.2.3
+        - haskell-lexer ^>= 1.1.1
+        - lifted-async ^>= 0.10.2.5
+        - polyparse ^>= 1.13
+        - silently ^>= 1.2.5.3
+        - text-icu ^>= 0.8.0.4
+        - vector-binary-instances ^>= 0.2.5.2
+        - map-syntax ^>= 0.3
+        - heist ^>= 1.1.1.2
+        - snap ^>= 1.1.3.3
+        - unix-compat ^>= 0.7.1
+
+
+    "Diogo Biazus <diogo@biazus.ca>":
+        - hasql-notifications ^>= 0.2.0.6
+
+    "David James <dj112358@outlook.com> @davjam":
+        - MapWith < 0
+
+    "Bernie Pope <florbitous@gmail.com> @bjpop":
+        - language-python ^>= 0.5.8
+
+    "Nils Alex <nils@famalex.de> @nilsalex":
+        - safe-tensor < 0
+
+    "Artur Gajowy <artur.gajowy@gmail.com> @ArturGajowy":
+        - ghc-clippy-plugin < 0
+
+    "Daniel Rolls <daniel.rolls.27@googlemail.com> @danielrolls":
+        - byte-count-reader ^>= 0.10.1.10
+        - shellify ^>= 0.11.0.0
+
+    "Allan Lukwago <epicallan.al@gmail.com> @epicallan":
+        - servant-errors < 0
+
+    "Christian Charukiewicz <charukiewicz@protonmail.com> @charukiewicz":
+        - isbn ^>= 1.1.0.4
+
+    "Koz Ross <koz.ross@retro-freedom.nz> @kozross":
+        - medea < 0
+
+    "Jappie Klooster <hi@jappie.me> @jappeace":
+        - yesod-middleware-csp ^>= 1.2.0
+        - persistent-lens ^>= 1.0.0
+        - mail-pool < 0
+        - keter ^>= 2.1.2
+        - zxcvbn-hs ^>= 0.3.6
+
+    "Marcin Rzeźnicki <marcin.rzeznicki@gmail.com> @marcin-rzeznicki":
+        - hspec-tables < 0
+        - stackcollapse-ghc < 0
+        - libjwt-typed < 0
+
+    "Mauricio Fierro <mauriciofierrom@gmail.com> @mauriciofierrom":
+        - dialogflow-fulfillment < 0
+
+    "Mihai Giurgeanu <mihai.giurgeanu@gmail.com> @mihaigiurgeanu":
+        - sqlcli < 0
+        - sqlcli-odbc < 0
+        # not a maintainer
+        - logging ^>= 3.0.5
+
+    "Sasha Bogicevic <sasa.bogicevic@pm.me> @v0d1ch":
+        - plaid ^>= 0.1.0.4
+
+    "Geoffrey Mainland <mainland@drexel.edu> @mainland":
+        - exception-mtl ^>= 0.4.0.2
+        - exception-transformers ^>= 0.4.0.12
+        - mainland-pretty ^>= 0.7.1
+        - ref-fd ^>= 0.5.0.1
+        - ref-tf ^>= 0.5.0.1
+        - srcloc ^>= 0.6.0.1
+        - symbol ^>= 0.2.4
+
+    "Patrick Bahr <paba@itu.dk>":
+        - compdata ^>= 0.13.1
+        - Rattus ^>= 0.5.1.1
+
+    "Rob Stewart <robstewart57@gmail.com> @robstewart57":
+        - gitlab-haskell < 0
+
+    "Callan McGill <callan.mcgill@gmail.com> @callanmcgill":
+        - perfect-vector-shuffle < 0
+
+    "Luke Clifton <lukec@themk.net> @luke-clifton":
+        - generic-monoid ^>= 0.1.0.1
+
+    "Tobias Reinhart <tobi.reinhart@fau.de> @TobiReinhart":
+        - sparse-tensor < 0
+
+    "Stephan Schiffels <stephan_schiffels@mac.com> @stschiff":
+        - sequence-formats ^>= 1.8.0.0
+        - pipes-ordered-zip ^>= 1.2.1
+        - sequenceTools ^>= 1.5.3.1
+
+    "YongJoon Joe <developer@quietjoon.net> @QuietJoon":
+        - doldol ^>= 0.4.1.2
+        - ENIG ^>= 0.0.1.0
+
+    "Chris Penner <christopher.penner@gmail.com> @ChrisPenner":
+        - eve < 0
+        - lens-regex-pcre ^>= 1.1.0.0
+        - lens-csv ^>= 0.1.1.0
+        - selections ^>= 0.3.0.0
+        - slick ^>= 1.2.1.0
+        - unipatterns ^>= 0.0.0.0
+
+    "Emily Pillmore <emilypi@cohomolo.gy> @topos":
+        - base16 ^>= 1.0
+        - base16-lens < 0
+        - base32 ^>= 0.4
+        - base32-lens < 0
+        - base64 ^>= 0.4.2.4
+        - base64-lens < 0
+        - lens-process < 0
+        - microlens-process < 0
+        - nonempty-vector ^>= 0.2.3
+        - smash < 0
+        - smash-aeson < 0
+        - smash-microlens < 0
+        - smash-lens < 0
+        - strict-tuple ^>= 0.1.5.3
+        - strict-tuple-lens < 0
+
+    "Matthieu Monsch <mtth@apache.org> @mtth":
+        - flags-applicative ^>= 0.1.0.3
+        - more-containers ^>= 0.2.2.2
+        - tracing ^>= 0.0.7.3
+
+    "Robert Vollmert <rob@vllmrt.net> @robx":
+        - configurator-pg ^>= 0.2.9
+        - postgrest < 0
+
+    "Sandy Maguire <sandy@sandymaguire.me> @isovector":
+        - ecstasy ^>= 0.2.1.0
+        - interpolatedstring-qq2 < 0
+        - prospect ^>= 0.1.0.0
+        - do-notation ^>= 0.1.0.2
+        - unagi-chan ^>= 0.4.1.4
+        - type-errors ^>= 0.2.0.2
+
+    "Matej Niznik <matten@tuta.io> @TheMatten":
+        - loopbreaker < 0
+
+    "William Yao <williamyaoh@gmail.com> @williamyaoh":
+        - string-interpolate ^>= 0.3.2.1
+
+    "Roel van Dijk <roel@lambdacube.nl> @roelvandijk":
+        - terminal-progress-bar ^>= 0.4.2
+
+    "Marek Fajkus <marek.faj@gmail.com> @turboMaCk":
+        - wai-enforce-https ^>= 1.0.0.0
+        - aeson-combinators ^>= 0.1.1.0
+
+    "Fernando Freire <dogonthehorizon@gmail.com> @dogonthehorizon":
+        - hal ^>= 1.0.1
+
+    "Nathan Fairhurst <nathan.fairhurst@nike.com> @iamfromspace":
+        - hal ^>= 1.0.1
+
+    "Daniel Taskoff <daniel.taskoff@gmail.com> @dtaskoff":
+        - hlibcpuid ^>= 0.2.0
+        - skip-var ^>= 0.1.1.0
+        - system-info ^>= 0.5.2
+
+    "Dzianis Kabanau <kobargh@gmail.com> @kobargh":
+        - template-toolkit < 0
+
+    "Christopher Davenport <chris@christopherdavenport.tech> @ChristopherDavenport":
+        - nonemptymap < 0
+        - hinfo ^>= 0.0.3.0
+
+    "Joerg Winter <jwin1968@gmail.com> @clojj":
+        - rosezipper ^>= 0.2
+
+    "Edward Wastell <edward@wastell.co.uk> @edwardwas":
+        - TotalMap < 0
+        - sized-grid < 0
+
+    "Antonio Alonso Dominguez <alonso.domin@gmail.com> @alonsodomin":
+        - hschema < 0
+        - hschema-aeson < 0
+        - hschema-prettyprinter < 0
+        - hschema-quickcheck < 0
+
+    "Preetham Gujjula <preetham.gujjula@gmail.com> @pgujjula":
+        - modular ^>= 0.1.0.8
+        - list-predicate ^>= 0.1.0.1
+        - primecount ^>= 0.1.0.1
+
+    "Guillaume Bouchard <guillaum.bouchard@gmail.com> @guibou":
+        - pretty-terminal ^>= 0.1.0.0
+        - PyF ^>= 0.11.2.1
+
+    "Erik Schnetter <schnetter@gmail.com> @eschnett":
+        - mpi-hs ^>= 0.7.2.0
+        - mpi-hs-binary ^>= 0.1.1.0
+        - mpi-hs-cereal ^>= 0.1.0.0
+
+    "Yang Bo <pop.atry@gmail.com> @Atry":
+        - control-dsl ^>= 0.2.1.3
+
+    "Laurent P. René de Cotret <laurent.decotret@outlook.com> @LaurentRDC":
+        - pandoc-plot ^>= 1.8.0
+
+    "Andrew Newman <andrewfnewman@gmail.com> @andrewfnewman":
+        - geojson ^>= 4.1.1
+
+    "Mateusz Karbowy <mateusz.karbowy@gmail.com> @obszczymucha":
+        - parsec-numbers ^>= 0.1.0
+
+    "Joshua Grosso <jgrosso256@gmail.com> @jgrosso":
+        - axel < 0
+
+    "Varun Gandhi <theindigamer15@gmail.com> @theindigamer":
+        - edit < 0
+
+    "Luka Hadžiegrić <reygoch@gmail.com> @reygoch":
+        - valor ^>= 1.0.0.0
+
+    "Scott N. Walck <walck@lvc.edu> @walck":
+        - cyclotomic ^>= 1.1.2
+        - learn-physics ^>= 0.6.6
+        - SpatialMath ^>= 0.2.7.1
+        - Vis ^>= 0.7.7.0
+        - LPFP ^>= 1.1.1
+        - LPFP-core ^>= 1.1.1
+
+    "Phil de Joux <phil.dejoux@blockscope.com> @philderbeast":
+        - siggy-chardust ^>= 1.0.0
+        - detour-via-sci ^>= 1.0.0
+        - hpack-dhall < 0
+
+    "Matthew Ahrens <matt.p.ahrens@gmail.com> @mpahrens":
+        - forkable-monad ^>= 0.2.0.3
+
+    "Iris Ward <aditu.venyhandottir@gmail.com> @AdituV":
+        - typenums ^>= 0.1.4
+
+    "Jude Taylor <me@jude.xyz> @pikajude":
+        - th-printf ^>= 0.8
+
+    "Christian Marie <christian@ponies.io> @christian-marie":
+        - git-vogue < 0 # 0.3.0.2 compile fail
+
+    "Manuel Bärenz <programming@manuelbaerenz.de> @turion":
+        - dunai < 0 # 0.12.0 9.6 compile fail https://github.com/ivanperez-keera/dunai/discussions/368
+        - essence-of-live-coding < 0 # 0.2.7 compile fail https://github.com/turion/essence-of-live-coding/issues/107
+        - essence-of-live-coding-gloss < 0
+        - essence-of-live-coding-pulse < 0
+        - essence-of-live-coding-quickcheck < 0
+        - essence-of-live-coding-warp < 0
+        - finite-typelits ^>= 0.1.6.0
+        - has-transformers ^>= 0.1.0.4
+        - monad-schedule ^>= 0.1.2.1
+        - pulse-simple ^>= 0.1.14
+        - rhine < 0
+        - rhine-gloss < 0
+        - simple-affine-space ^>= 0.2.1
+        - time-domain ^>= 0.1.0.2
+
+    "Paul Johnson <paul@cogito.org.uk> @PaulJohnson":
+        - geodetics ^>= 0.1.2
+        - Ranged-sets ^>= 0.4.0
+
+    "Travis Athougies <travis@athougies.net> @tathougies":
+        - beam-core ^>= 0.10.1.0
+        - beam-migrate < 0
+        - beam-mysql < 0
+        - beam-postgres < 0
+        - beam-sqlite < 0
+
+    "Fraser Murray <fraser.m.murray@gmail.com @intolerable":
+        - stitch ^>= 0.6.0.0
+
+    "Yusent Chig <yusent@protonmail.com> @yusent":
+        - yesod-auth-bcryptdb < 0
+
+    "Johannes Gerer <oss@johannesgerer.com>":
+        - buchhaltung < 0
+
+    "Tom McLaughlin <tom@codedown.io> @thomasjm":
+        - aeson-typescript ^>= 0.6.1.0
+        - fsnotify ^>= 0.4.1.0
+        - myers-diff ^>= 0.3.0.0
+        - sandwich ^>= 0.2.1.0
+        - sandwich-hedgehog ^>= 0.1.3.0
+        - sandwich-quickcheck ^>= 0.1.0.7
+        - sandwich-slack ^>= 0.1.2.0
+        - sandwich-webdriver ^>= 0.2.3.1
+        - slack-progressbar < 0 # 0.1.0.1 https://github.com/codedownio/slack-progressbar/issues/1
+        - system-linux-proc ^>= 0.1.1.1 # @erikd
+        - webdriver ^>= 0.12.0.0
+
+    "Paulo Tanaka <paulot@fb.com> @paulot":
+        # on behalf of Bryan O'Sullivan @bos:
+        - zstd ^>= 0.1.3.0
+
+    "Jacek Galowicz <jacek@galowicz.de> @tfc":
+        - hamtsolo ^>= 1.0.4
+
+    "Ferdinand van Walree <ferdinandvwalree@gmail.com> @Ferdinand-vW":
+        - tuple-sop ^>= 0.3.1.0
+        - sessiontypes < 0
+        - sessiontypes-distributed < 0
+
+    "Jacob Thomas Errington <tsani@mail.jerrington.me> @tsani":
+        - servant-github-webhook < 0
+        - pushbullet-types < 0
+
+    "Theodore Lief Gannon <tanuki@gmail.com> @tejon":
+        - aeson-yak ^>= 0.1.1.3
+        - safe-foldable ^>= 0.1.0.0
+
+    "Florian Knupfer <fknupfer@gmail.com> @knupfer":
+        - type-of-html ^>= 1.6.2.0
+        - type-of-html-static ^>= 0.1.0.2
+        - chronos-bench ^>= 0.2.0.2
+
+    "Mikolaj Konarski <mikolaj.konarski@funktory.com> @Mikolaj":
+        - sdl2-ttf ^>= 2.1.3
+        - enummapset ^>= 0.7.2.0
+        - assert-failure ^>= 0.1.3.0
+        - minimorph ^>= 0.3.0.1
+        - miniutter ^>= 0.5.1.2
+        - LambdaHack ^>= 0.11.0.1
+        - Allure ^>= 0.11.0.0
+
+    "Jürgen Keck <jhyphenkeck@gmail.com> @j-keck":
+        - wreq-stringless ^>= 0.5.9.1
+
+    "Olaf Chitil <oc@kent.ac.uk> @OlafChitil":
+        - FPretty < 0
+
+    "Maarten Faddegon <stackage@maartenfaddegon.nl> @MaartenFaddegon":
+        - libgraph < 0
+        - Hoed < 0
+
+    "Agustin Camino <agustin.camino@gmail.com> @acamino":
+        - state-codes ^>= 0.1.3
+
+    "Sebastian Mihai Ardelean <ardeleanasm@gmail.com> @ardeleanasm":
+        - qchas ^>= 1.1.0.1
+
+    "Patrick Pelletier <code@funwithsoftware.org> @ppelleti":
+        - mercury-api < 0
+        - normalization-insensitive < 0
+
+    "Jacob Stanley <jacob@stanley.io> @jacobstanley":
+        - hedgehog ^>= 1.4
+        - hedgehog-quickcheck ^>= 0.1.1
+        - transformers-bifunctors < 0
+
+    "Walter Schulze <awalterschulze@gmail.com> @awalterschulze":
+        - katydid < 0
+
+    "Nobutada Matsubara <t12307043@gunma-u.ac.jp> @matsubara0507":
+        - chatwork < 0
+        - rakuten < 0
+        - servant-kotlin < 0
+
+    "Pavol Klacansky <pavol@klacansky.com> @pavolzetor":
+        - openexr-write ^>= 0.1.0.2
+
+    "Pasqualino Assini <tittoassini@gmail.com> @tittoassini":
+        - zm < 0
+        - flat ^>= 0.6
+        - model < 0
+
+    "Jose Iborra <pepeiborra@gmail.com> @pepeiborra":
+        - arrowp-qq < 0
+        - haskell-src-exts-util ^>= 0.2.5
+        - hexml-lens ^>= 0.2.2
+        - hp2pretty ^>= 0.10
+        - floatshow ^>= 0.2.4
+        - ghc-check ^>= 0.5.0.8
+
+    "Roman Gonzalez <open-source@roman-gonzalez.info> @roman":
+        - componentm ^>= 0.0.0.2
+        - componentm-devel ^>= 0.0.0.2
+        - teardown ^>= 0.5.0.1
+        - etc < 0
+        - capataz < 0
+
+    "Richard Cook <rcook@rcook.org> @rcook":
+        - hidden-char < 0
+        - oset < 0
+        - req-url-extra < 0
+        - sexpr-parser < 0
+
+    "Vanessa McHale <vmchale@gmail.com> @vmchale":
+        - bz2 ^>= 1.0.1.0
+
+    "Henning Thielemann <stackage@henning-thielemann.de> @thielema":
+        - accelerate-arithmetic < 0
+        - accelerate-fftw < 0
+        - accelerate-fourier < 0
+        - accelerate-utility < 0
+        - align-audio ^>= 0.0.0.1
+        - alsa-core ^>= 0.5.0.1
+        - alsa-pcm ^>= 0.6.1.1
+        - alsa-seq ^>= 0.6.0.9
+        - apportionment ^>= 0.0.0.4
+        - audacity ^>= 0.0.2.1
+        - battleship-combinatorics ^>= 0.0.1
+        - bibtex ^>= 0.1.0.7
+        - board-games ^>= 0.4
+        - boomwhacker ^>= 0.0.1
+        - buffer-pipe ^>= 0.0
+        - cabal-flatpak < 0
+        - cabal-sort ^>= 0.1.2
+        - calendar-recycling ^>= 0.0.0.1
+        - checksum ^>= 0.0.0.1
+        - coinor-clp ^>= 0.0.0.1
+        - combinatorial ^>= 0.1.1
+        - comfort-graph ^>= 0.0.4
+        - comfort-array ^>= 0.5.3
+        - comfort-array-shape ^>= 0.0
+        - comfort-fftw ^>= 0.0.0.1
+        - comfort-glpk ^>= 0.1
+        - concurrent-split ^>= 0.0.1.1
+        - cutter ^>= 0.0
+        - data-accessor ^>= 0.2.3.1
+        - data-accessor-mtl ^>= 0.2.0.5
+        - data-accessor-template < 0
+        - data-accessor-transformers ^>= 0.2.1.8
+        - data-ref ^>= 0.1
+        - doctest-exitcode-stdio ^>= 0.0
+        - doctest-extract ^>= 0.1.1.1
+        - doctest-lib ^>= 0.1
+        - dsp ^>= 0.2.5.2
+        - enumset ^>= 0.1
+        - equal-files ^>= 0.0.5.4
+        - event-list ^>= 0.1.2.1
+        - explicit-exception ^>= 0.2
+        - fixed-length ^>= 0.2.3.1
+        - fftw-ffi ^>= 0.1
+        - ghostscript-parallel ^>= 0.0
+        - gnuplot ^>= 0.5.7
+        - group-by-date ^>= 0.1.0.5
+        - guarded-allocation ^>= 0.0.1
+        - iff ^>= 0.0.6.1
+        - interpolation ^>= 0.1.1.2
+        - jack ^>= 0.7.2.2
+        - latex ^>= 0.1.0.4
+        - lazyio ^>= 0.1.0.4
+        - linear-programming ^>= 0.0.0.1
+        - markov-chain ^>= 0.0.3.4
+        - midi ^>= 0.2.2.4
+        - midi-alsa ^>= 0.2.1
+        - midi-music-box ^>= 0.0.1.2
+        - mbox-utility ^>= 0.0.3.1
+        - med-module ^>= 0.1.3
+        - monoid-transformer ^>= 0.0.4
+        - non-empty ^>= 0.3.5
+        - non-negative ^>= 0.1.2
+        - numeric-prelude ^>= 0.4.4
+        - numeric-quest ^>= 0.2.0.2
+        - ods2csv ^>= 0.1
+        - pathtype ^>= 0.8.1.2
+        - pooled-io ^>= 0.0.2.3
+        - probability ^>= 0.2.8
+        - quickcheck-transformer ^>= 0.3.1.2
+        - reactive-banana-bunch ^>= 1.0.0.1
+        - reactive-midyim ^>= 0.4.1.1
+        - reactive-balsa ^>= 0.4.0.1
+        - reactive-jack ^>= 0.4.1.2
+        - sample-frame ^>= 0.0.4
+        - sample-frame-np ^>= 0.0.5
+        - set-cover ^>= 0.1.1
+        - shell-utility ^>= 0.1
+        - sound-collage ^>= 0.2.1
+        - sox ^>= 0.2.3.2
+        - soxlib ^>= 0.0.3.2
+        - split-record ^>= 0.1.1.4
+        - spreadsheet ^>= 0.1.3.10
+        - stm-split ^>= 0.0.2.1
+        - storable-record ^>= 0.0.7
+        - storable-tuple ^>= 0.1
+        - storablevector ^>= 0.2.13.2
+        - synthesizer-core ^>= 0.8.3
+        - synthesizer-dimensional ^>= 0.8.1.1
+        - synthesizer-alsa ^>= 0.5.0.6
+        - synthesizer-midi ^>= 0.6.1.2
+        - tagchup ^>= 0.4.1.2
+        - tfp ^>= 1.0.2
+        - unicode ^>= 0.0.1.1
+        - unique-logic ^>= 0.4.0.1
+        - unique-logic-tf ^>= 0.5.1
+        - unsafe ^>= 0.0
+        - utility-ht ^>= 0.0.17
+        - wraxml ^>= 0.5
+        - xml-basic ^>= 0.1.3.2
+        - youtube ^>= 0.2.1.1
+        - prelude-compat ^>= 0.0.0.2
+        - fft ^>= 0.1.8.7
+        - carray ^>= 0.1.6.8
+        - lapack-ffi-tools ^>= 0.1.3.1
+        - netlib-ffi ^>= 0.1.1
+        - blas-ffi ^>= 0.1
+        - lapack-ffi ^>= 0.0.3
+        - netlib-carray ^>= 0.1
+        - blas-carray ^>= 0.1.0.2
+        - lapack-carray ^>= 0.0.3
+        - netlib-comfort-array ^>= 0.0.0.2
+        - blas-comfort-array ^>= 0.0.0.3
+        - lapack-comfort-array ^>= 0.0.1
+        - comfort-blas ^>= 0.0.1
+        - lapack ^>= 0.5.1
+        - lapack-hmatrix ^>= 0.0.0.2
+        - hmm-lapack ^>= 0.5.0.1
+        - magico ^>= 0.0.2.3
+        - resistor-cube ^>= 0.0.1.4
+        - linear-circuit ^>= 0.1.0.4
+        # Not a maintainer
+        - cabal-plan ^>= 0.7.3.0
+        - topograph ^>= 1.0.0.2
+        - ix-shapable ^>= 0.1.0
+        - hyper ^>= 0.2.1.1
+        - storable-endian ^>= 0.2.6.1
+        - glpk-headers ^>= 0.5.1
+        - derive-storable ^>= 0.3.1.0
+
+    "Jeremy Barisch-Rooney <barischj@tcd.ie> @barischrooneyj":
+        - threepenny-gui-flexbox < 0 # 0.4.2 compile fail https://github.com/jerbaroo/threepenny-gui-flexbox/issues/5
+
+    "Romain Edelmann <romain.edelmann@gmail.com> @redelmann":
+        - distribution < 0
+
+    "Nikita Tchayka <nikitatchayka@gmail.com> @nickseagull":
+        - ramus ^>= 0.1.2
+        - require < 0
+        - tintin < 0
+        - aws-lambda-haskell-runtime < 0
+
+    "Simon Jakobi <simon.jakobi@gmail.com> @sjakobi":
+        - threepenny-gui ^>= 0.9.4.0
+        - newtype-generics ^>= 0.6.2
+        - bsb-http-chunked ^>= 0.0.0.4
+        - hspec-parsec ^>= 0
+        - checkers ^>= 0.6.0
+        - unordered-containers ^>= 0.2.19.1
+        - prettyprinter ^>= 1.7.1
+        - prettyprinter-ansi-terminal ^>= 1.1.3
+        - prettyprinter-compat-wl-pprint ^>= 1.0.1
+        - prettyprinter-compat-ansi-wl-pprint ^>= 1.0.2
+        - prettyprinter-compat-annotated-wl-pprint ^>= 1.1
+        - prettyprinter-convert-ansi-wl-pprint < 0
+        - HsYAML ^>= 0.2.1.3
+        - HsYAML-aeson ^>= 0.2.0.1
+
+    "Joe M <joe9mail@gmail.com> @joe9":
+        - logger-thread ^>= 0.1.0.2
+        - text-generic-pretty < 0
+
+    "Li-yao Xia <lysxia@gmail.com> @Lysxia":
+        - ap-normalize ^>= 0.1.0.1
+        - boltzmann-samplers ^>= 0.1.1.0
+        - diff-loc ^>= 0.1.0.0
+        - first-class-families ^>= 0.8.0.1
+        - fcf-family ^>= 0.2.0.0
+        - generic-data ^>= 1.1.0.0
+        - generic-data-surgery ^>= 0.3.0.0
+        - generic-functor ^>= 1.1.0.0
+        - generic-random ^>= 1.5.0.1
+        - scanf ^>= 0.1.0.0
+        - show-combinators ^>= 0.2.0.0
+        - type-map ^>= 0.1.7.0
+        - quickcheck-higherorder ^>= 0.1.0.1
+        - test-fun ^>= 0.1.0.0
+
+    "Solomon Bothwell <ssbothwell@gmail.com> @solomon-b":
+        - monoidal-functors ^>= 0.2.3.0
+
+    "Tobias Dammers <tdammers@gmail.com> @tdammers":
+        - ginger ^>= 0.10.5.2
+        - yeshql < 0
+
+    "Yair Chuchem <yairchu@gmail.com> @yairchu":
+        - generic-constraints ^>= 1.1.1.1
+        - git-mediate ^>= 1.0.9
+        - List ^>= 0.6.2
+        - ListTree ^>= 0.2.3
+
+    "Marco Zocca @ocramz":
+        - ad-delcont ^>= 0.5.0.0
+        - sparse-linear-algebra < 0
+        - depq ^>= 0.4.2
+        - matrix-market-attoparsec ^>= 0.1.1.3
+        - splitmix-distributions ^>= 1.0.0
+        - rp-tree ^>= 0.7.1
+        - xeno ^>= 0.6
+        - bytestring-mmap < 0 # 0.2.2 required by xeno # not ghc 9.6 ready
+        - datasets < 0
+        - lucid-extras ^>= 0.2.2
+        - mnist-idx-conduit ^>= 0.4.0.0
+        - rigel-viz < 0
+
+    "Joseph Canero <jmc41493@gmail.com> @caneroj1":
+        - sqlite-simple-errors < 0
+        - median-stream ^>= 0.7.0.0
+        - stm-supply ^>= 0.2.0.0
+        - filter-logger ^>= 0.6.0.0
+        - tile ^>= 0.3.0.0
+        - mbtiles < 0 # 0.6.0.0 compile fail
+
+    "James M.C. Haver II <mchaver@gmail.com> @mchaver":
+        - quickcheck-arbitrary-adt ^>= 0.3.1.0
+        - hspec-golden-aeson ^>= 0.9.0.0
+        - quickcheck-arbitrary-template < 0
+
+    "Winter Han <winterland1989@gmail.com> @winterland1989":
+        - if ^>= 0.1.0.0
+        - tcp-streams < 0 # 1.0.1.1 https://github.com/didi-FP/tcp-streams/issues/9
+        - tcp-streams-openssl < 0
+        - wire-streams < 0
+        - binary-parsers < 0
+        - binary-ieee754 ^>= 0.1.0.0
+        - word24 < 0
+        - mysql-haskell ^>= 1.1.3
+        - mysql-haskell-openssl < 0
+        - data-has ^>= 0.4.0.0
+        - unboxed-ref ^>= 0.4.0.0
+
+    "Harendra Kumar <harendra.kumar@gmail.com> @harendra-kumar":
+        - bench-show < 0
+        - monad-recorder < 0
+        - packcheck ^>= 0.6.0
+        - streamly ^>= 0.10.0
+        - streamly-core ^>= 0.2.0
+        - unicode-transforms ^>= 0.4.0.1
+        - xls < 0
+
+    "Ranjeet Ranjan <rnjt.ranjan@gmail.com> @rnjtranjan":
+        - streamly-process < 0
+        - streamly-examples < 0
+
+    "Pranay Sashank <pranaysashank@gmail.com> @pranaysashank":
+        - fusion-plugin-types ^>= 0.1.0
+        - fusion-plugin ^>= 0.2.7
+
+    "Adithya Kumar <adi.obilisetty@gmail.com> @adithyaov":
+        - unicode-data ^>= 0.4.0.1
+
+    "Aleksey Uimanov <s9gf4ult@gmail.com> @s9gf4ult":
+        - postgresql-query ^>= 3.10.0
+        - hreader ^>= 1.1.1
+        - hset ^>= 2.2.0
+        - base58-bytestring ^>= 0.1.0
+
+    "Aaron Taylor <aaron@hamsterdam.co> @hamsterdam":
+        - kawhi < 0
+
+    "Schell Scivally <schell@zyghost.com> @schell":
+        - renderable ^>= 0.2.0.1
+        - varying ^>= 0.8.1.0
+
+    "Nicolas Mattia <nicolas@nmattia.com> @nmattia":
+        - makefile < 0
+
+    "Siddharth Bhat <siddu.druid@gmail.com> @bollu":
+        - symengine ^>= 0.1.2.0
+
+    "alpheccar <misc@alpheccar.org> @alpheccar":
+        - HPDF ^>= 1.6.2
+
+    "Dmitry Bogatov <KAction@gnu.org> @iu-guest":
+        - once ^>= 0.4
+        - mbug < 0
+
+    "David Johnson <djohnson.m@gmail.com> @dmjio":
+        - miso ^>= 1.8.3.0
+        - envy ^>= 2.1.2.0
+        - s3-signer ^>= 0.5.0.0
+        - google-translate < 0
+        - hackernews < 0
+        - ses-html ^>= 0.4.0.0
+        - stripe-haskell < 0
+        - stripe-http-client < 0
+        - stripe-core < 0
+        - stripe-tests < 0
+
+    "Piotr Mlodawski @pmlodawski":
+        - error-util < 0 # 0.0.1.2 MonadFail
+        - signal ^>= 0.1.0.4
+
+    "Michael Snoyman michael@snoyman.com @snoyberg":
+        - bzlib-conduit ^>= 0.3.0.2
+        - case-insensitive ^>= 1.2.1.0
+        - classy-prelude-yesod ^>= 1.5.0
+        - conduit-combinators ^>= 1.3.0
+        - conduit-extra ^>= 1.3.6
+        - hebrew-time ^>= 0.1.2
+        - markdown ^>= 0.1.17.5
+        - mime-mail ^>= 0.5.1
+        - mime-mail-ses ^>= 0.4.3
+        - mime-types ^>= 0.1.2.0
+        - network-conduit-tls ^>= 1.4.0
+        - persistent ^>= 2.14.6.0
+        - persistent-mysql ^>= 2.13.1.5
+        - persistent-postgresql ^>= 2.13.6.1
+        - persistent-sqlite ^>= 2.13.3.0
+        - persistent-template ^>= 2.12.0.0
+        - persistent-test ^>= 2.13.1.3
+        - store ^>= 0.7.18
+        - wai-extra ^>= 3.1.13.0
+        - wai-websockets ^>= 3.0.1.2
+        - warp-tls ^>= 3.4.3
+        - yesod ^>= 1.6.2.1
+        - authenticate ^>= 1.3.5.2
+        - html-conduit ^>= 1.3.2.2
+        - yesod-auth ^>= 1.6.11.2
+        - authenticate-oauth ^>= 1.7
+        - yesod-bin < 0 # 1.6.2.2 https://github.com/yesodweb/yesod/issues/1804
+        - yesod-eventsource ^>= 1.6.0.1
+        - yesod-gitrepo ^>= 0.3.0
+        - yesod-newsfeed ^>= 1.7.0.0
+        - yesod-sitemap ^>= 1.6.0
+        - yesod-static ^>= 1.6.1.0
+        - yesod-test ^>= 1.6.16
+        - yesod-websockets ^>= 0.3.0.3
+        - cereal-conduit ^>= 0.8.0
+        - binary-conduit ^>= 1.3.1
+        - lzma-conduit < 0
+        - mutable-containers ^>= 0.3.4.1
+        - hpc-coveralls < 0
+        - monad-unlift < 0
+        - monad-unlift-ref < 0
+        - yaml ^>= 0.11.11.2
+        - servius ^>= 1.2.3.0
+        - cryptonite-conduit ^>= 0.2.2
+        - streaming-commons ^>= 0.2.2.6
+
+        - async ^>= 2.2.5
+        - base16-bytestring ^>= 1.0.2.0
+        - csv-conduit < 0
+        - executable-hash ^>= 0.2.0.4
+        - executable-path ^>= 0.0.3.1
+        - foreign-store ^>= 0.2
+        - formatting ^>= 7.2.0
+        - gtk2hs-buildtools ^>= 0.13.10.0
+        - hybrid-vectors ^>= 0.2.4
+        - indents ^>= 0.5.0.1
+        - language-c ^>= 0.9.2
+        - persistent-mongoDB ^>= 2.13.0.1
+        - pretty-class ^>= 1.0.1.1
+        - th-expand-syns ^>= 0.4.11.0
+        - th-lift ^>= 0.8.4
+        - quickcheck-assertions ^>= 0.3.0
+
+        - wai-middleware-crowd < 0
+        - monad-logger-json ^>= 0.1.0.0
+        - safe-exceptions ^>= 0.1.7.4
+        - fsnotify-conduit < 0 # 0.1.1.1 compile fail https://github.com/commercialhaskell/stackage/issues/6768
+        - pid1 ^>= 0.1.3.1
+        - typed-process ^>= 0.2.11.1
+        - say ^>= 0.1.0.1
+        - unliftio-core ^>= 0.2.1.0
+        - unliftio ^>= 0.2.25.0
+
+        - hinotify ^>= 0.4.1
+        - hfsevents ^>= 0.1.6
+        - Win32-notify ^>= 0.3.0.3
+        - windns ^>= 0.1.0.1
+
+        - mono-traversable ^>= 1.0.15.3
+        - http-client ^>= 0.7.15
+        - http-conduit ^>= 2.3.8.3
+        - githash ^>= 0.1.7.0
+
+        - time-manager ^>= 0.0.1
+        - pantry ^>= 0.9.3.1
+        - mega-sdist ^>= 0.4.3.0
+        - http-download ^>= 0.2.1.0
+        - hi-file-parser ^>= 0.1.6.0
+        - rio-prettyprint ^>= 0.1.7.0
+        - packdeps < 0
+
+    "Brandon Barker <brandon.barnnker@gmail.com> @bbarker":
+        - unexceptionalio ^>= 0.5.1
+        - unexceptionalio-trans < 0 # 0.5.1 # fails to compile https://github.com/singpolyma/unexceptionalio-trans/issues/2
+        - zio < 0
+
+    "Omari Norman <omari@smileystation.com> @massysett":
+        - rainbow ^>= 0.34.2.2
+        - rainbox ^>= 0.26.0.0
+        - multiarg ^>= 0.30.0.10
+        - ofx ^>= 0.4.4.0
+        - accuerr < 0
+        - timelens ^>= 0.2.0.2
+        - squeather ^>= 0.8.0.0
+
+    "Neil Mitchell <ndmitchell@gmail.com> @ndmitchell":
+        - hlint ^>= 3.6.1
+        - hoogle < 0
+        - shake ^>= 0.19.7
+        - tagsoup ^>= 0.14.8
+        - cmdargs ^>= 0.10.22
+        - safe ^>= 0.3.19
+        - uniplate ^>= 1.6.13
+        - nsis ^>= 0.3.3
+        - js-jquery ^>= 3.3.1
+        - js-flot ^>= 0.8.3
+        - js-dgtable ^>= 0.5.2
+        - extra ^>= 1.7.14
+        - ghcid ^>= 0.8.9
+        - hexml ^>= 0.3.4
+        - profiterole < 0
+        - record-dot-preprocessor < 0
+        - filepattern ^>= 0.1.3
+        - record-hasfield ^>= 1.0
+        - rattle ^>= 0.2
+        - fuzzy ^>= 0.1.0.1
+
+    "Digital Asset <shayne@shaynefletcher.org> @shayne-fletcher":
+        - ghc-lib ^>= 9.6.3.20231121
+        - ghc-lib-parser ^>= 9.6.3.20231121
+
+    "Shayne Fletcher <shayne@shaynefletcher.org> @shayne-fletcher":
+        - ghc-lib-parser-ex ^>= 9.6.0.2
+
+    "Karl Ostmo <kostmo@gmail.com> @kostmo":
+        - perfect-hash-generator ^>= 1.0.0
+
+    "Alan Zimmerman @alanz":
+        - ghc-exactprint ^>= 1.7.0.1
+        - hjsmin ^>= 0.2.1
+        - language-javascript ^>= 0.7.1.0
+        - Strafunski-StrategyLib < 0
+
+    "Michael Peyton Jones <me@michaelpj.com>":
+        - lsp-types ^>= 2.1.0.0
+        - lsp ^>= 2.3.0.0
+        - lsp-test ^>= 0.16.0.1
+
+    "Alfredo Di Napoli <alfredo.dinapoli@gmail.com> @adinapoli":
+        - mandrill ^>= 0.5.7.0
+
+    "Jon Schoning <jonschoning@gmail.com> @jonschoning":
+        - pinboard < 0
+        - swagger-petstore < 0
+
+    "Jasper Van der Jeugt @jaspervdj":
+        - blaze-html ^>= 0.9.1.2
+        - blaze-markup ^>= 0.8.3.0
+        - stylish-haskell ^>= 0.14.5.0
+        - profiteur < 0
+        - psqueues ^>= 0.2.8.0
+        - websockets ^>= 0.12.7.3
+        - websockets-snap ^>= 0.10.3.1
+
+    "Jasper Van der Jeugt @jaspervdj & Alexander Batischev <eual.jp@gmail.com> @Minoru":
+        - hakyll ^>= 4.16.2.0
+
+    "Sibi Prabakaran <sibi@psibi.in> @psibi":
+        - download ^>= 0.3.2.7
+        - textlocal ^>= 0.1.0.5
+        - shell-conduit ^>= 5.0.0
+        - tldr ^>= 0.9.2
+        - fb ^>= 2.1.1.1
+        - yesod-fb ^>= 0.6.1
+        - yesod-auth-fb < 0 # 1.1.0.1 compile fail
+        - hourglass-orphans ^>= 0.1.0.0
+        - wai-slack-middleware ^>= 0.2.0
+        - sysinfo ^>= 0.1.1
+        - xmonad-extras < 0
+        - persistent-redis ^>= 2.13.0.1
+        - fakedata ^>= 1.0.3
+        - fakedata-parser ^>= 0.1.0.0
+        - fakedata-quickcheck ^>= 0.2.0
+        - streamly-bytestring < 0
+        - crypton-conduit ^>= 0.2.3
+
+    "haskell-openal @svenpanne":
+        - OpenAL ^>= 1.7.0.5
+        - ALUT ^>= 2.4.0.3
+
+    "haskell-opengl @svenpanne":
+        - OpenGL ^>= 3.0.3.0
+        - GLURaw ^>= 2.0.0.5
+        - GLUT ^>= 2.7.0.16
+        - OpenGLRaw ^>= 3.3.4.1
+        - StateVar ^>= 1.2.2
+        - ObjectName ^>= 1.1.0.2
+
+    "Antoine Latter @aslatter":
+        - byteorder ^>= 1.0.4
+        - uuid ^>= 1.3.15
+
+    "Philipp Middendorf <pmidden@secure.mailbox.org> @pmiddend":
+        - clock ^>= 0.8.4
+
+    "Stefan Wehr <mail@stefanwehr.de> @skogsbaer":
+        - HTF ^>= 0.15.0.1
+        - xmlgen ^>= 0.6.2.2
+        - stm-stats < 0
+        - large-hashable < 0
+
+    "Bart Massey <bart.massey+stackage@gmail.com> @BartMassey":
+        - parseargs ^>= 0.2.0.9
+
+    "Vincent Hanquez @vincenthz":
+        - basement ^>= 0.0.16
+        - bytedump ^>= 1.0
+        - cipher-aes ^>= 0.2.11
+        - cipher-rc4 ^>= 0.1.4
+        - connection < 0
+        - cprng-aes < 0
+        - cpu ^>= 0.1.2
+        - cryptocipher < 0
+        - cryptohash ^>= 0.11.9
+        - cryptonite ^>= 0.30
+        - cryptonite-openssl ^>= 0.7
+        - crypto-pubkey-types ^>= 0.4.3
+        - crypto-random-api ^>= 0.2.0
+        - foundation ^>= 0.0.30
+        - gauge ^>= 0.2.5
+        - git < 0 # 0.3.0 compile fail MonadFail
+        - hit < 0
+        - memory ^>= 0.18.0
+        - language-java ^>= 0.2.9
+        - libgit < 0 # 0.3.1 compile fail https://github.com/vincenthz/hs-libgit/issues/7
+        - pem ^>= 0.2.4
+        - siphash < 0
+        - socks ^>= 0.6.1
+        - tasty-kat ^>= 0.0.3
+        - tls ^>= 1.8.0
+        - tls-debug < 0
+        - vhd < 0 # 0.2.2 compile fail: Missing Semigroup Checksum
+        - xenstore < 0 # 0.1.1 compile fail: sClose not in scope
+
+    "Chris Done @chrisdone":
+        - labels ^>= 0.3.3
+        - ace ^>= 0.6
+        - check-email ^>= 1.0.2
+        - freenect ^>= 1.2.1
+        - frisby ^>= 0.2.5
+        - gd ^>= 3000.7.3
+        - hostname-validate ^>= 1.0.0
+        - lucid ^>= 2.11.20230408
+        - lucid2 ^>= 0.0.20230706
+        - pdfinfo < 0
+        - pure-io < 0
+        - sourcemap ^>= 0.1.7
+        - descriptive < 0
+        - wrap ^>= 0.0.0
+        - path ^>= 0.9.5
+        - weigh ^>= 0.0.17
+        - odbc < 0
+        - structured-haskell-mode < 0
+        - casa-client ^>= 0.0.2
+        - casa-types ^>= 0.0.2
+
+    "Alberto G. Corona <agocorona@gmail.com> @agocorona":
+        - RefSerialize ^>= 0.4.0
+        - TCache < 0 # 0.13.3 compile fail
+        - Workflow < 0
+        - MFlow < 0
+        - transient < 0 # 0.7.0.0 # fails to compile (#7017)
+        - transient-universe < 0
+        - axiom < 0
+
+    "Edward Kmett <ekmett@gmail.com> @ekmett":
+        - ad ^>= 4.5.4
+        - adjunctions ^>= 4.4.2
+        - algebra ^>= 4.3.1
+        - ansi-wl-pprint ^>= 1.0.2
+        - approximate ^>= 0.3.5
+        - bifunctors ^>= 5.6.1
+        - bits ^>= 0.6
+        - bound ^>= 2.0.7
+        - bytes ^>= 0.17.3
+        - charset ^>= 0.3.10
+        - comonad ^>= 5.0.8
+        - compensated ^>= 0.8.3
+        - compressed < 0
+        - concurrent-supply ^>= 0.1.8
+        - constraints ^>= 0.14
+        - contravariant ^>= 1.5.5
+        - distributive ^>= 0.6.2.1
+        - discrimination ^>= 0.5
+        - either ^>= 5.0.2
+        - eq ^>= 4.3
+        - ersatz ^>= 0.5
+        - fixed ^>= 0.3
+        - folds ^>= 0.7.8
+        - free ^>= 5.2
+        - gl ^>= 0.9
+        - graphs ^>= 0.7.2
+        - half ^>= 0.3.1
+        - heaps ^>= 0.4
+        - hybrid-vectors ^>= 0.2.4
+        - hyperloglog ^>= 0.4.6
+        - hyphenation ^>= 0.8.2
+        - indexed-traversable ^>= 0.1.3
+        - integration ^>= 0.2.1
+        - intern ^>= 0.9.5
+        - intervals ^>= 0.9.2
+        - kan-extensions ^>= 5.2.5
+        - keys ^>= 3.12.3
+        - lca ^>= 0.4
+        - lens ^>= 5.2.3
+        - lens-action ^>= 0.2.6
+        - lens-aeson ^>= 1.2.3
+        - lens-properties ^>= 4.11.1
+        - linear ^>= 1.22
+        - linear-accelerate < 0
+        - log-domain ^>= 0.13.2
+        - machines ^>= 0.7.3
+        - monadic-arrays < 0
+        - monad-products < 0
+        - monad-st ^>= 0.2.4.1
+        # - mtl take the one that ships with GHC
+        - nats ^>= 1.1.2
+        - numeric-extras ^>= 0.1
+        - parsers ^>= 0.12.11
+        - pointed ^>= 5.0.4
+        - profunctors ^>= 5.6.2
+        - promises ^>= 0.3
+        - rcu ^>= 0.2.7
+        - reducers ^>= 3.12.4
+        - reflection ^>= 2.1.7
+        - semigroupoid-extras < 0
+        - semigroupoids ^>= 6.0.0.1
+        - semigroups ^>= 0.20
+        - speculation < 0
+        - streams ^>= 3.3.2
+        - structs ^>= 0.1.9
+        - tagged ^>= 0.8.8
+        - tagged-transformer ^>= 0.8.2
+        - transformers-compat ^>= 0.7.2
+        - trifecta ^>= 2.1.3
+        - unique ^>= 0.0.1
+        - vector-instances ^>= 3.4.2
+        - void ^>= 0.7.3
+        - wl-pprint-extras < 0
+        - wreq ^>= 0.5.4.2
+        - wl-pprint-terminfo < 0
+        - zippers ^>= 0.3.2
+        - zlib-lens < 0
+
+    "Andrew Farmer <afarmer@ittc.ku.edu> @xich":
+        - scotty ^>= 0.20.1 && <0.21 # https://github.com/commercialhaskell/stackage/issues/7208
+        - wai-middleware-static ^>= 0.9.2
+
+    "Simon Hengel <sol@typeful.net> @sol":
+        - hpack ^>= 0.36.0
+        - hspec ^>= 2.11.7
+        - hspec-api ^>= 2.11.7
+        - hspec-core ^>= 2.11.7
+        - hspec-discover ^>= 2.11.7
+        - hspec-wai ^>= 0.11.1
+        - hspec-wai-json ^>= 0.11.0
+        - aeson-qq ^>= 0.8.4
+        - interpolate ^>= 0.2.1
+        - doctest ^>= 0.22.2
+        - base-compat ^>= 0.13.1
+
+    "Mario Blazevic <blamario@protonmail.com> @blamario":
+        - monad-parallel ^>= 0.8
+        - monad-coroutine ^>= 0.9.2
+        - monoid-subclasses ^>= 1.2.4.1
+        - rank2classes ^>= 1.5.3
+        - input-parsers ^>= 0.3.0.2
+        - incremental-parser < 0
+        - construct < 0
+
+    "Brent Yorgey <byorgey@gmail.com> @byorgey":
+        - active ^>= 0.2.1
+        - statestack ^>= 0.3.1.1
+        - diagrams ^>= 1.4.1
+        - diagrams-builder ^>= 0.8.0.6
+        - diagrams-cairo ^>= 1.4.2.1
+        - diagrams-canvas ^>= 1.4.1.2
+        - diagrams-contrib ^>= 1.4.5.1
+        - diagrams-core ^>= 1.5.1.1
+        - diagrams-gtk ^>= 1.4
+        - diagrams-html5 ^>= 1.4.2
+        - diagrams-lib ^>= 1.4.6
+        - diagrams-postscript ^>= 1.5.1.1
+        - diagrams-rasterific ^>= 1.4.2.3
+        - diagrams-solve ^>= 0.1.3
+        - diagrams-svg ^>= 1.4.3.1
+        - force-layout ^>= 0.4.0.6
+        - SVGFonts ^>= 1.8.0.1
+        - haxr ^>= 3000.11.5
+        - MonadRandom ^>= 0.6
+        - monoid-extras ^>= 0.6.2
+
+    "Vincent Berthoux <vincent.berthoux@gmail.com> @Twinside":
+        - JuicyPixels ^>= 3.3.8
+        - FontyFruity ^>= 0.5.3.5
+        - Rasterific ^>= 0.7.5.4
+        - svg-tree ^>= 0.6.2.4
+        - rasterific-svg ^>= 0.3.3.2
+        - asciidiagram < 0
+
+    "Patrick Brisbin @pbrisbin":
+        - bugsnag-haskell ^>= 0.0.4.4
+        - bugsnag ^>= 1.1.0.0
+        - bugsnag-wai ^>= 1.0.0.1
+        - bugsnag-yesod ^>= 1.0.1.0
+        - gravatar ^>= 0.8.1
+        - load-env ^>= 0.2.1.0
+        - shellwords ^>= 0.1.3.1
+        - yesod-markdown ^>= 0.12.6.13
+        - yesod-paginator ^>= 1.1.2.2
+
+    "Freckle Engineering <freckle-engineering@renaissance.com> @pbrisbin @mjgpy3 @stevenxl":
+        - Blammo ^>= 1.1.2.1
+        - aws-sns-verify ^>= 0.0.0.3
+        - aws-xray-client ^>= 0.1.0.2
+        - aws-xray-client-persistent ^>= 0.1.0.5
+        - aws-xray-client-wai ^>= 0.1.0.2
+        - bcp47 ^>= 0.2.0.6
+        - bcp47-orphans ^>= 0.1.0.6
+        - faktory ^>= 1.1.2.5
+        - graphula ^>= 2.1.0.0
+        - hspec-expectations-json ^>= 1.0.2.1
+        - hspec-junit-formatter ^>= 1.1.0.2
+        - nonempty-zipper ^>= 1.0.0.4
+        - scientist ^>= 0.0.0.0
+        - sendgrid-v3 ^>= 1.0.0.1
+        - yesod-auth-oauth2 ^>= 0.7.1.3
+        - yesod-page-cursor ^>= 2.0.1.0
+        - yesod-routes-flow ^>= 3.0.0.2
+
+    "Felipe Lessa <felipe.lessa@gmail.com> @meteficha":
+        - fb ^>= 2.1.1.1
+        - nonce ^>= 1.0.7
+        - serversession ^>= 1.0.3
+        - serversession-backend-persistent < 0
+        - serversession-backend-redis ^>= 1.0.5
+        - serversession-frontend-wai ^>= 1.0.1
+        - serversession-frontend-yesod ^>= 1.0.1
+        - thumbnail-plus < 0
+        - yesod-auth-fb < 0 # 1.10.1 compile fail
+        - yesod-fb ^>= 0.6.1
+
+    "Alexander Altman <alexanderaltman@me.com> @pthariensflame":
+        # Maintaining on behalf of @roelvandijk:
+        - base-unicode-symbols ^>= 0.2.4.2
+        - containers-unicode-symbols < 0
+        # My own packages:
+        - ChannelT ^>= 0.0.0.7
+
+    "Trevor L. McDonell <trevor.mcdonell@gmail.com> @tmcdonell":
+        - accelerate < 0
+        - accelerate-bignum < 0
+        - accelerate-blas < 0
+        - accelerate-fft < 0
+        - accelerate-io < 0
+        - accelerate-llvm < 0
+        - accelerate-llvm-native < 0
+        - accelerate-llvm-ptx < 0
+        - accelerate-examples < 0
+        - repa < 0
+        - repa-algorithms < 0
+        - repa-io < 0
+        - gloss ^>= 1.13.2.2
+        - gloss-rendering ^>= 1.13.1.2
+        - gloss-algorithms ^>= 1.13.0.3
+        - gloss-examples < 0
+        - gloss-raster < 0
+        - gloss-accelerate < 0
+        - gloss-raster-accelerate < 0
+        - colour-accelerate < 0
+        - lens-accelerate < 0
+        - mwc-random-accelerate < 0
+        - cuda ^>= 0.11.0.1
+        - cufft < 0 # 0.10.0.0 compile fail (#7198)
+        - cublas < 0 # 0.6.0.0 compile fail (#7198)
+        - cusparse < 0 # 0.3.0.0 compile fail (#7198)
+        - cusolver < 0
+        - nvvm ^>= 0.10.0.1
+        - wide-word ^>= 0.1.6.0 # @erikd
+
+    "Dan Burton <danburton.email@gmail.com> @DanBurton":
+        - ANum ^>= 0.2.0.2
+        - basic-prelude ^>= 0.7.0
+        - composition ^>= 1.0.2.2
+        - haskell-src-meta ^>= 0.8.13
+        - io-memoize ^>= 1.1.1.0
+        - lens-family-th < 0
+        - numbers ^>= 3000.2.0.2
+        - rev-state < 0
+        - runmemo ^>= 1.0.0.1
+        - tardis < 0 # 0.4.4.0 # fails to compile https://github.com/DanBurton/tardis/issues/15
+        - yesod-gitrev ^>= 0.2.2
+        # @mr's packages
+        - ftp-client < 0
+        - ftp-client-conduit < 0
+        # other: real maintainers pls steal these back
+        - text-format ^>= 0.3.2.1 # needed by liquid-fixpoint
+        - liquid-fixpoint < 0
+
+    "Daniel Casanueva <daniel.casanueva@proton.me> @Daniel-Diaz":
+        - binary-list ^>= 1.1.1.2
+        - bounded-qsem ^>= 0.1.0.1
+        - byteset ^>= 0.1.1.1
+        - Clipboard ^>= 2.3.2.0
+        - fgl-arbitrary ^>= 0.2.0.6
+        - gmail-simple ^>= 0.1.0.5
+        - graphviz ^>= 2999.20.2.0
+        - grouped-list < 0
+        - haskintex ^>= 0.8.0.2
+        - HaTeX ^>= 3.22.4.1
+        - hetzner ^>= 0.6.0.0
+        - include-file ^>= 0.1.0.4
+        - journalctl-stream ^>= 0.6.0.5
+        - mailtrap ^>= 0.1.2.0
+        - matrix ^>= 0.3.6.3
+        - mysql-json-table ^>= 0.1.2.0
+        - pcre-light ^>= 0.4.1.2
+        - phantom-state ^>= 0.2.1.4
+        - post-mess-age ^>= 0.2.1.0
+        - sorted-list ^>= 0.2.2.0
+
+    "Gabriella Gonzalez <GenuineGabriella@gmail.com> @Gabriella439":
+        - optparse-generic ^>= 1.5.2
+        - pipes ^>= 4.3.16
+        - pipes-extras ^>= 1.0.15
+        - pipes-http ^>= 1.0.6
+        - pipes-parse ^>= 3.0.9
+        - pipes-concurrency ^>= 2.0.14
+        - pipes-safe ^>= 2.3.5
+        - turtle ^>= 1.6.2
+        - foldl ^>= 1.4.15
+        - bench < 0
+        - dhall ^>= 1.42.1
+        - dhall-bash ^>= 1.0.41
+        - dhall-json < 0
+        - dhall-lsp-server < 0
+        - dhall-yaml < 0
+        - dhall-nix < 0
+        - nix-derivation ^>= 1.1.3
+        - list-transformer ^>= 1.1.0
+
+    "Andrew Thaddeus Martin <andrew.thaddeus@gmail.com> @andrewthad":
+        - colonnade ^>= 1.2.0.2
+        - blaze-colonnade ^>= 1.2.2.1
+        - dot ^>= 0.3
+
+    "Chris Allen <cma@bitemyapp.com> @bitemyapp":
+        - machines-directory < 0
+        - machines-io < 0
+        - bloodhound ^>= 0.21.0.0
+
+    "Adam Bergmark <adam@bergmark.nl> @bergmark":
+        - aeson ^>= 2.1.2.1
+        - HUnit ^>= 1.6.2.0
+        - attoparsec-iso8601 ^>= 1.1.0.1
+        - feed ^>= 1.3.2.1
+        - time-compat ^>= 1.9.6.1
+        - through-text < 0
+        # Not my packages
+        - HStringTemplate ^>= 0.8.8
+        - spoon ^>= 0.3.1
+        - tagshare < 0 # 0.0 # fails to compile (#7017)
+
+    "Benedict Aas <x@shou.io> @Shou":
+        - boolean-like < 0
+        - type-operators < 0
+
+    "Sebastiaan Visser <haskell@fvisser.nl> @sebastiaanvisser":
+        - clay ^>= 0.14.0
+        - fclabels ^>= 2.0.5.1
+
+    "Robert Klotzner <robert.klotzner@gmx.at> @eskimor":
+        - purescript-bridge ^>= 0.15.0.0
+        - servant-purescript < 0 # 0.10.0.0 compile fail #6091/closed
+        - servant-subscriber ^>= 0.7.0.0
+
+    "Rodrigo Setti <rodrigosetti@gmail.com> @rodrigosetti":
+        - messagepack ^>= 0.5.5
+        - messagepack-rpc < 0
+
+    "Boris Lykah <lykahb@gmail.com> @lykahb":
+        - groundhog < 0
+        - groundhog-inspector < 0
+        - groundhog-mysql < 0
+        - groundhog-postgresql < 0
+        - groundhog-sqlite < 0
+        - groundhog-th < 0
+
+    "Janne Hellsten <jjhellst@gmail.com> @nurpax":
+        - sqlite-simple ^>= 0.4.18.2
+
+    "Michal J. Gajda <maintainer@migamake.com> @mgajda":
+        - iterable < 0
+        - FenwickTree ^>= 0.1.2.1
+        - json-autotype < 0
+
+    "Dom De Re <domdere@domdere.com> @domdere":
+        - cassava-conduit ^>= 0.6.5
+
+    "Dominic Steinitz <dominic@steinitz.org> @idontgetoutmuch":
+        - monad-bayes < 0
+        - random-fu ^>= 0.3.0.1
+
+    "Ben Gamari <ben@smart-cactus.org> @bgamari":
+        - vector-fftw < 0
+        - cborg-json ^>= 0.2.6.0
+        - language-dot ^>= 0.1.2
+
+    "Roman Cheplyaka <roma@ro-che.info> @feuerbach":
+        - action-permutations ^>= 0.0.0.1
+        - amqp ^>= 0.22.2
+        - heredoc ^>= 0.2.0.0
+        - immortal ^>= 0.3
+        - regex-applicative ^>= 0.3.4
+        - lexer-applicative ^>= 2.1.0.2
+        - tasty ^>= 1.4.3
+        - tasty-golden ^>= 2.3.5
+        - tasty-hunit ^>= 0.10.1
+        - tasty-quickcheck ^>= 0.10.2
+        - tasty-smallcheck ^>= 0.8.2
+        - tasty-html ^>= 0.4.2.1
+        - time-lens ^>= 0.4.0.2
+        - timezone-olson ^>= 0.2.1
+        - timezone-series ^>= 0.1.13
+        - traverse-with-class ^>= 1.0.1.1
+        - tuples-homogenous-h98 ^>= 0.1.1.0
+
+    "George Giorgidze <giorgidze@gmail.com> @giorgidze":
+        - YampaSynth < 0 # 0.2 compile fail
+        - set-monad ^>= 0.3.0.0
+
+    "Phil Hargett <phil@haphazardhouse.net> @hargettp":
+        - courier < 0
+
+    "Aycan iRiCAN <iricanaycan@gmail.com> @aycanirican":
+        - hdaemonize ^>= 0.5.7
+        - hweblib ^>= 0.6.3
+
+    "Joachim Breitner <mail@joachim-breitner.de> @nomeata":
+        - arbtt < 0
+        - rec-def ^>= 0.2.2
+        - bytestring-progress < 0 # dependency of arbtt
+        - circle-packing ^>= 0.1.0.6
+        - haskell-spacegoo < 0
+        - tasty-expected-failure ^>= 0.12.3
+
+    "Aditya Bhargava <adit@adit.io> @egonSchiele":
+        - HandsomeSoup ^>= 0.4.2
+
+    "Clint Adams <clint@debian.org> @clinty":
+        - hOpenPGP < 0
+        - openpgp-asciiarmor ^>= 0.1.2
+        - MusicBrainz ^>= 0.4.1
+        - DAV ^>= 1.3.4
+        - hopenpgp-tools < 0
+        - opensource ^>= 0.1.1.0
+        - debian ^>= 4.0.5
+        - cabal-debian ^>= 5.2.2
+        # dependencies:
+        - monad-chronicle ^>= 1.0.1
+
+    "Piyush P Kurur <ppk@cse.iitk.ac.in> @piyush-kurur":
+        - raaz < 0
+        - naqsha < 0
+
+    "Joey Hess <id@joeyh.name> @joeyh":
+        - git-annex ^>= 10.20231129
+        - concurrent-output ^>= 1.10.20
+        - mountpoints ^>= 1.0.2
+        - disk-free-space ^>= 0.1.0.1
+
+    "Colin Woodbury <colin@fosskers.ca> @fosskers":
+        - aur < 0
+        - aura < 0
+        - bounded-queue ^>= 1.0.0
+        - kanji < 0
+        - language-bash < 0
+        - microlens-aeson ^>= 2.5.1
+        - pipes-random ^>= 1.0.0.5
+        - servant-xml ^>= 1.0.2
+        - streaming-attoparsec ^>= 1.0.0.1
+        - versions ^>= 6.0.3
+        - vectortiles < 0
+
+    "Ketil Malde @ketil-malde":
+        - biocore < 0
+        - biofasta < 0
+        - biofastq < 0
+        - blastxml < 0
+        - bioace < 0
+        - biopsl < 0
+        - seqloc < 0
+        - bioalign < 0
+        - BlastHTTP < 0
+
+    "Florian Eggenhofer <florian.eggenhofer@univie.ac.at> @eggzilla":
+        - ClustalParser ^>= 1.3.0
+        - EntrezHTTP < 0
+        - Genbank < 0
+        - RNAlien < 0
+        - biocore < 0
+        - bimaps ^>= 0.1.0.2
+        - BiobaseBlast < 0
+        - BiobaseENA < 0
+        - BiobaseEnsembl ^>= 0.2.0.1
+        - BiobaseFasta < 0
+        - BiobaseHTTP < 0
+        - BiobaseTypes < 0
+        - BiobaseXNA < 0
+        - DPutils ^>= 0.1.1.0
+        - ForestStructures ^>= 0.0.1.1
+        - OrderedBits ^>= 0.0.2.0
+        - PrimitiveArray < 0 # 0.10.1.1 compile fail
+        - SciBaseTypes ^>= 0.1.1.0
+        - Taxonomy < 0
+        - ViennaRNAParser ^>= 1.3.3
+        - either-unwrap ^>= 1.1
+
+    "Silk <code@silk.co>":
+        - attoparsec-expr ^>= 0.1.1.2
+        - generic-xmlpickler < 0
+        - imagesize-conduit ^>= 1.1
+        - multipart ^>= 0.2.1
+        - tostring ^>= 0.2.1.1
+        - uri-encode ^>= 1.5.0.7
+
+    "Simon Michael <simon@joyful.com> @simonmichael":
+        - quickbench < 0
+        - regex-compat-tdfa < 0
+        - shelltestrunner ^>= 1.10
+        # The hledger project aims to keep the latest release of the core
+        # "hledger-lib" and "hledger" packages in stackage nightly at all times.
+        # When other hledger-* packages (or minor non-hledger packages) have
+        # incompatible bounds, we would prefer they be disabled temporarily,
+        # rather than disabling the latest hledger-lib and hledger.
+        # (#3494/closed, #5779/closed)
+        - hledger ^>= 1.32.1
+        - hledger-lib ^>= 1.32.1
+        - hledger-ui < 0
+        - hledger-web ^>= 1.32.1
+        - breakpoint ^>= 0.1.3.0
+
+    "Mihai Maruseac <mihai.maruseac@gmail.com> @mihaimaruseac":
+        - hindent ^>= 6.1.1
+        - io-manager ^>= 0.1.0.4
+
+    "Dimitri Sabadie <dimitri.sabadie@gmail.com> @phaazon":
+        - al < 0
+        - event < 0
+        - hid < 0
+        - monad-journal < 0
+        - smoothie < 0
+        - wavefront < 0
+        - zero < 0
+
+    "Thomas Schilling <nominolo@googlemail.com> @nominolo":
+        - ghc-syb-utils < 0
+
+    "Boris Buliga <d12frosted@icloud.com> @d12frosted":
+        - io-choice < 0
+
+    "Yann Esposito <yann.esposito@gmail.com> yogsototh @yogsototh":
+        - human-readable-duration ^>= 0.2.1.4
+        - holy-project < 0
+        - wai-middleware-caching ^>= 0.1.0.2
+        - wai-middleware-caching-lru ^>= 0.1.0.0
+        - wai-middleware-caching-redis ^>= 0.2.0.0
+
+    "Paul Rouse <pgr@doynton.org> @paul-rouse":
+        - mysql ^>= 0.2.1
+        - mysql-simple ^>= 0.4.9
+        - sphinx < 0 # 0.6.0.2 compile fail: Could not find module Network
+        - xmlhtml ^>= 0.2.5.4
+        - yesod-auth-hashdb ^>= 1.7.1.7
+
+    "Toralf Wittner <tw@dtex.org> @twittner":
+        - bytestring-conversion ^>= 0.3.2
+        - cql ^>= 4.0.4
+        - cql-io ^>= 1.1.1
+        - redis-resp ^>= 1.0.0
+        - redis-io < 0
+        - swagger < 0
+        - tinylog < 0
+        - wai-predicates < 0
+        - wai-routing < 0
+        - zeromq4-haskell ^>= 0.8.0
+
+    "Alejandro Serrano <trupill@gmail.com> @serras":
+        - djinn-lib ^>= 0.0.1.4
+        - djinn-ghc < 0
+        - generics-mrsop < 0 # 2.3.0 compile fail: TyVarBndr
+        - kind-apply ^>= 0.4.0.0
+        - kind-generics ^>= 0.5.0.0
+        - kind-generics-th ^>= 0.2.3.3
+        - simplistic-generics < 0
+        - wl-pprint ^>= 1.2.1
+        - AC-Angle ^>= 1.0
+        - language-protobuf ^>= 1.0.1
+        - generic-aeson < 0
+        - parameterized ^>= 0.5.0.0
+        - tracing-control < 0
+        - primitive-unlifted ^>= 2.1.0.0 && (<1.0.0.0 || >1.0.0.0)
+        - stm-lifted < 0
+        - monad-primitive < 0 # 0.1 compile fail ghc-9.6
+        - mwc-random-monad < 0
+
+    "Flavio Corpa <flaviocorpa@gmail.com> @kutyel":
+        - language-avro ^>= 0.1.4.0
+
+    "Matvey Aksenov <matvey.aksenov@gmail.com> @supki":
+        - terminal-size ^>= 0.3.4
+        - envparse ^>= 0.5.0
+
+    "Luis G. Torres <lgtorres42@gmail.com> @giogadi":
+        - kdt ^>= 0.2.5
+
+    "Pavel Krajcevski <krajcevski@gmail.com> @Mokosha":
+        - netwire ^>= 5.0.3
+        - netwire-input ^>= 0.0.7
+        - netwire-input-glfw < 0 # 0.0.11 compile fail https://github.com/Mokosha/netwire-input-glfw/issues/5
+        - yoga ^>= 0.0.0.5
+        - freetype2 ^>= 0.2.0
+        - HCodecs ^>= 0.5.2
+        - netcode-io ^>= 0.0.3
+        - reliable-io ^>= 0.0.2
+
+    "Michael Sloan <mgsloan@gmail.com> @mgsloan":
+        - store ^>= 0.7.18
+        - store-core ^>= 0.4.4.6
+        - store-streaming ^>= 0.2.0.5
+        - th-orphans ^>= 0.13.14
+        - th-reify-many ^>= 0.1.10
+        - th-utilities ^>= 0.2.5.0
+
+    "Nikita Volkov <nikita.y.volkov@mail.ru> @nikita-volkov":
+        - acc ^>= 0.2.0.3
+        - aeson-unqualified-ast ^>= 1.0.0.3
+        - aeson-value-parser ^>= 0.19.7.2
+        - attoparsec-data ^>= 1.0.5.4
+        - attoparsec-time ^>= 1.0.3.1
+        - base-prelude ^>= 1.6.1.1
+        - bytestring-strict-builder ^>= 0.4.5.7
+        - bytestring-tree-builder ^>= 0.2.7.11
+        - cases ^>= 0.1.4.2
+        - cereal-unordered-containers ^>= 0.1.0.1
+        - deferred-folds ^>= 0.9.18.6
+        - deque ^>= 0.4.4.1
+        - domain ^>= 0.1.1.5
+        - domain-aeson ^>= 0.1.1.2
+        - domain-cereal ^>= 0.1.0.1
+        - domain-core ^>= 0.1.0.4
+        - domain-optics ^>= 0.1.0.4
+        - focus ^>= 1.0.3.2
+        - hasql ^>= 1.6.3.4
+        - hasql-optparse-applicative ^>= 0.7.1.1
+        - hasql-pool ^>= 0.10.0.1
+        - hasql-th ^>= 0.4.0.19
+        - hasql-transaction ^>= 1.0.1.2
+        - headed-megaparsec ^>= 0.2.1.3
+        - isomorphism-class ^>= 0.1.0.12
+        - jsonifier ^>= 0.2.1.3
+        - list-t ^>= 1.0.5.7
+        - mtl-prelude ^>= 2.0.3.2
+        - neat-interpolation ^>= 0.5.1.4
+        - optima ^>= 0.4.0.5
+        - partial-handler ^>= 1.0.3
+        - postgresql-binary ^>= 0.13.1.2
+        - postgresql-syntax ^>= 0.4.1.1
+        - primitive-extras ^>= 0.10.1.10
+        - ptr-poker ^>= 0.1.2.14
+        - rebase ^>= 1.20.2
+        - rerebase ^>= 1.20.2
+        - slave-thread ^>= 1.1.0.3
+        - stm-containers ^>= 1.2.0.3
+        - stm-hamt ^>= 1.2.0.14
+        - template-haskell-compat-v0208 ^>= 0.1.9.3
+        - text-builder ^>= 0.6.7.2
+        - text-builder-dev ^>= 0.3.4.2
+        - th-lego ^>= 0.3.0.3
+        - vector-builder ^>= 0.3.8.5
+        - vector-extras ^>= 0.2.8.1
+        - yaml-unscrambler ^>= 0.1.0.18
+        - xml-parser < 0
+
+    "Iustin Pop <iustin@k1024.org> @iustin":
+        - prefix-units ^>= 0.3.0.1
+
+    "Alexander Thiemann <mail@athiemann.net> @agrafix":
+        - Spock < 0
+        - Spock-core < 0 # 0.14.0.1 https://github.com/agrafix/Spock/issues/184
+        - Spock-api ^>= 0.14.0.0
+        - Spock-api-server < 0
+        - Spock-worker < 0
+        - graph-core ^>= 0.3.0.0
+        - hvect ^>= 0.4.0.1
+        - reroute ^>= 0.7.0.0
+        - users ^>= 0.5.0.0
+        - users-persistent < 0
+        - users-postgresql-simple < 0 # 0.5.0.2 # fails to compile (#7017)
+        - users-test ^>= 0.5.0.1
+        - validate-input ^>= 0.5.0.0
+        - ignore < 0 # 0.1.1.0 compile fail https://github.com/agrafix/ignore/issues/5
+        - blaze-bootstrap ^>= 0.1.0.1
+        - dataurl ^>= 0.1.0.0
+        - psql-helpers ^>= 0.1.0.0
+        - superbuffer ^>= 0.3.1.2
+        - timespan ^>= 0.4.0.0
+        - distance < 0 # 0.1.0.0 compile fail: Semigroup Distance
+        - async-extra ^>= 0.2.0.0
+        - format-numbers ^>= 0.1.0.1
+        - highjson < 0
+        - highjson-swagger < 0
+        - highjson-th < 0
+        - fileplow ^>= 0.1.0.0
+
+    "Joey Eremondi <joey@eremondi.com> @JoeyEremondi":
+        - digest ^>= 0.0.2.0
+        - elm-core-sources ^>= 1.0.0
+        - language-glsl ^>= 0.3.0
+        - prettyclass ^>= 1.0.0.0
+        - QuasiText ^>= 0.1.2.6
+        - union-find < 0
+        - zip-archive ^>= 0.4.3
+
+    "Arthur Fayzrakhmanov <heraldhoi@gmail.com> @geraldus":
+        - yesod-form-richtext < 0
+        - ghcjs-perch ^>= 0.3.3.3
+
+    "Tom Ellis <tom-stackage@jaguarpaw.co.uk> @tomjaguarpaw":
+        - opaleye ^>= 0.10.2.0
+        - product-profunctors ^>= 0.11.1.1
+        - strict-wrapper ^>= 0.0.0.0
+
+    "Samplecount stefan@samplecount.com @kaoskorobase":
+        - shake-language-c ^>= 0.12.0
+
+    "David Turner <dave.c.turner@gmail.com> @davecturner":
+        - alarmclock ^>= 0.7.0.6
+        - bank-holidays-england ^>= 0.2.0.9
+
+    "Haskell Servant <haskell-servant-maintainers@googlegroups.com>":
+        - servant ^>= 0.20.1
+        - servant-blaze ^>= 0.9.1
+        - servant-cassava < 0
+        - servant-client ^>= 0.20
+        - servant-client-core ^>= 0.20
+        - servant-conduit ^>= 0.16
+        - servant-docs ^>= 0.13
+        - servant-foreign ^>= 0.16
+        - servant-http-streams ^>= 0.20
+        - servant-js < 0
+        - servant-lucid ^>= 0.9.0.6
+        - servant-machines ^>= 0.16
+        - servant-mock < 0
+        - servant-multipart ^>= 0.12.1
+        - servant-multipart-api ^>= 0.12.1
+        - servant-pipes ^>= 0.16
+        - servant-server ^>= 0.20
+        - servant-swagger ^>= 1.2
+        - servant-swagger-ui ^>= 0.3.5.5.0.0
+        - servant-swagger-ui-core ^>= 0.3.5
+
+    "Optics <optics@well-typed.com>":
+        - indexed-profunctors ^>= 0.1.1.1
+        - optics ^>= 0.4.2.1
+        - optics-core ^>= 0.4.1.1
+        - optics-extra ^>= 0.4.2.1
+        - optics-th ^>= 0.4.1
+        - optics-vl ^>= 0.2.1
+
+    "Alexandr Ruchkin <voidex@live.com> @mvoidex":
+        - hformat ^>= 0.3.3.1
+        - simple-log < 0
+        - text-region < 0
+        - haskell-names < 0
+        - hsdev < 0
+
+    "Aleksey Kliger <aleksey@lambdageek.org> @lambdageek":
+        - unbound-generics < 0
+        - indentation-core < 0
+        - indentation-parsec < 0
+        - clang-compilation-database < 0
+
+    "Alois Cochard <alois.cochard@gmail.com> @aloiscochard":
+        - machines-binary < 0
+        # on behalf of Bryan O'Sullivan @bos:
+        - wreq ^>= 0.5.4.2
+
+    "Andraz Bajt <andraz@bajt.me> @edofic":
+        - effect-handlers < 0
+        - koofr-client < 0
+        - snowflake ^>= 0.1.1.1
+
+    "Leza M. Lutonda <lemol-c@hotmail.com> @lemol":
+        - HaskellNet ^>= 0.6.1.2
+        - HaskellNet-SSL < 0
+
+    "Tristan de Cacqueray <tdecacqu@redhat.com> @tristanC":
+        - linux-capabilities ^>= 0.1.1.0
+
+    "Jens Petersen <juhpetersen@gmail.com> @juhp":
+        - bodhi ^>= 0.1.0
+        - bugzilla-redhat ^>= 1.0.1.1
+        - cabal-file ^>= 0.1.1
+        - cabal-rpm ^>= 2.1.5
+        - cached-json-file ^>= 0.1.1
+        - copr-api ^>= 0.2.0
+        - dl-fedora ^>= 1.0
+        - fedora-dists ^>= 2.1.1
+        - fedora-haskell-tools ^>= 1.1
+        - HaXml ^>= 1.25.13
+        - hkgr ^>= 0.4.3.2
+        - http-directory ^>= 0.1.10
+        - http-query ^>= 0.1.3
+        - hwk ^>= 0.6
+        - koji ^>= 0.0.2
+        - koji-tool ^>= 1.1.1
+        - pagure ^>= 0.1.1
+        - pagure-cli ^>= 0.2.1
+        - pdc ^>= 0.1.1
+        - pkgtreediff ^>= 0.6.0
+        - rhbzquery < 0 # 0.4.4 https://github.com/juhp/rhbzquery/issues/1
+        - rpm-nvr ^>= 0.1.2
+        - rpmbuild-order ^>= 0.4.10
+        - simple-cabal ^>= 0.1.3.1
+        - simple-cmd ^>= 0.2.7
+        - simple-cmd-args ^>= 0.1.8
+        - simple-prompt ^>= 0.2.2
+        - stack-all ^>= 0.4.2
+        - stack-clean-old ^>= 0.5
+
+        - darcs < 0
+        - idris < 0
+        - libffi ^>= 0.2.1
+        - cairo ^>= 0.13.10.0
+        - glib ^>= 0.13.10.0
+        - gio ^>= 0.13.10.0
+        - pango ^>= 0.13.10.0
+        - gtk3 ^>= 0.15.8
+        - ghcjs-codemirror ^>= 0.0.0.2
+        - ghcjs-dom < 0
+        - jsaddle ^>= 0.9.8.3
+        - vado < 0
+        - vcswrapper < 0
+        - ShellCheck ^>= 0.9.0
+        - binary-shared ^>= 0.8.3
+        - xdg-userdirs ^>= 0.1.0.2
+
+    "Renzo Carbonara <renzocarbonara@gmail.com> @k0001":
+        - df1 ^>= 0.4.2
+        - di ^>= 1.3
+        - di-core ^>= 1.0.4
+        - di-df1 ^>= 1.2.1
+        - di-handle ^>= 1.0.1
+        - di-monad ^>= 1.3.5
+        - exinst ^>= 0.9
+        - flay ^>= 0.4
+        - network-simple ^>= 0.4.5
+        - network-simple-tls < 0 # 0.4.1 compile fail https://github.com/k0001/network-simple/issues/37
+        - pipes-aeson < 0
+        - pipes-attoparsec ^>= 0.6.0
+        - pipes-binary ^>= 0.4.4
+        - pipes-network < 0
+        - pipes-network-tls < 0
+        - safe-money ^>= 0.9.1
+        - vector-bytes-instances ^>= 0.1.1
+        - xmlbf-xeno ^>= 0.2.2
+        - xmlbf-xmlhtml ^>= 0.2.2
+        - xmlbf ^>= 0.7
+
+    "Tomas Carnecky @wereHamster":
+        - avers < 0
+        - avers-api < 0
+        - avers-server < 0
+        - css-syntax ^>= 0.1.0.1
+        - etcd < 0
+        - github-types ^>= 0.2.1
+        - github-webhook-handler < 0
+        - github-webhook-handler-snap < 0
+        - google-cloud < 0
+        - kraken < 0
+        - libinfluxdb < 0
+        - mole < 0
+        - publicsuffix < 0
+        - rethinkdb-client-driver < 0
+        - snap-blaze ^>= 0.2.1.5
+
+    "Alexandr Kurilin <alex@kurilin.net> @alex_kurilin":
+        - bcrypt ^>= 0.0.11
+
+    "Jeffrey Rosenbluth <jeffrey.rosenbluth@gmail.com> @jeffreyrosenbluth":
+        - palette ^>= 0.3.0.3
+        - diagrams-canvas ^>= 1.4.1.2
+        - svg-builder ^>= 0.1.1
+
+    "Leon Mergen <leon@solatis.com> @solatis":
+        - base32string ^>= 0.9.1
+        - base58string ^>= 0.10.0
+        - bitcoin-api < 0
+        - bitcoin-api-extra < 0
+        - bitcoin-block < 0
+        - bitcoin-script < 0
+        - bitcoin-tx < 0
+        - bitcoin-types < 0
+        - hexstring < 0
+        - network-attoparsec < 0 # 0.12.2 compile fail MonadFail
+        - network-anonymous-i2p < 0 # 0.10.0 compile fail
+        - network-anonymous-tor < 0
+
+    "Timothy Jones <tim@zmthy.net> @zmthy":
+        - http-media ^>= 0.8.1.1
+
+    "Greg V <greg@unrelenting.technology> @myfreeweb":
+        - pcre-heavy ^>= 1.0.0.3
+        - http-link-header ^>= 1.2.1
+        - microformats2-parser < 0 # 1.0.2.2 compile fail aeson >= 2
+        - hspec-expectations-pretty-diff ^>= 0.7.2.6
+        - wai-cli ^>= 0.2.3
+        - magicbane < 0
+
+    "Francesco Mazzoli <f@mazzo.li> @bitonic":
+        - language-c-quote ^>= 0.13.0.1
+
+    "Sönke Hahn <soenkehahn@gmail.com> @soenkehahn":
+        - generics-eot ^>= 0.4.0.1
+        - getopt-generics ^>= 0.13.1.0
+        - graph-wrapper ^>= 0.2.6.0
+        - string-conversions ^>= 0.4.0.1
+        - hspec-checkers ^>= 0.1.0.2
+        - FindBin ^>= 0.0.5
+
+    "Jan Stolarek <jan.stolarek@p.lodz.pl> @jstolarek":
+        - tasty-program ^>= 1.1.0
+
+    "Abhinav Gupta <mail@abhinavg.net> @abhinav":
+        - farmhash < 0
+        - pinch ^>= 0.5.0.0
+        - sandman < 0 # 0.2.0.1 compile fail (Cabal 3)
+
+    "Adam C. Foltzer <acfoltzer@galois.com> @acfoltzer":
+        - gitrev ^>= 1.3.1
+        - persistent-refs < 0 # 0.4 compile fail https://github.com/acfoltzer/persistent-refs/issues/3
+
+    "Luke Taylor <tekul.hs@gmail.com> @tekul":
+        - jose-jwt ^>= 0.9.6
+
+    "Brendan Hay <brendan.g.hay@gmail.com> @brendanhay":
+        - amazonka ^>= 2.0
+        - amazonka-core ^>= 2.0
+        - amazonka-test ^>= 2.0
+        - amazonka-accessanalyzer ^>= 2.0
+        - amazonka-account ^>= 2.0
+        - amazonka-amp ^>= 2.0
+        - amazonka-amplify ^>= 2.0
+        - amazonka-amplifybackend ^>= 2.0
+        - amazonka-amplifyuibuilder ^>= 2.0
+        - amazonka-apigateway ^>= 2.0
+        - amazonka-apigatewaymanagementapi ^>= 2.0
+        - amazonka-apigatewayv2 ^>= 2.0
+        - amazonka-appconfig ^>= 2.0
+        - amazonka-appconfigdata ^>= 2.0
+        - amazonka-appflow ^>= 2.0
+        - amazonka-appintegrations ^>= 2.0
+        - amazonka-application-autoscaling ^>= 2.0
+        - amazonka-application-insights ^>= 2.0
+        - amazonka-applicationcostprofiler ^>= 2.0
+        - amazonka-appmesh ^>= 2.0
+        - amazonka-apprunner ^>= 2.0
+        - amazonka-appstream ^>= 2.0
+        - amazonka-arc-zonal-shift ^>= 2.0
+        - amazonka-athena ^>= 2.0
+        - amazonka-auditmanager ^>= 2.0
+        - amazonka-autoscaling ^>= 2.0
+        - amazonka-backup ^>= 2.0
+        - amazonka-backup-gateway ^>= 2.0
+        - amazonka-backupstorage ^>= 2.0
+        - amazonka-billingconductor ^>= 2.0
+        - amazonka-braket ^>= 2.0
+        - amazonka-budgets ^>= 2.0
+        - amazonka-certificatemanager ^>= 2.0
+        - amazonka-chime ^>= 2.0
+        - amazonka-chime-sdk-identity ^>= 2.0
+        - amazonka-chime-sdk-media-pipelines ^>= 2.0
+        - amazonka-chime-sdk-meetings ^>= 2.0
+        - amazonka-chime-sdk-messaging ^>= 2.0
+        - amazonka-chime-sdk-voice ^>= 2.0
+        - amazonka-cloudcontrol ^>= 2.0
+        - amazonka-cloudformation ^>= 2.0
+        - amazonka-cloudfront ^>= 2.0
+        - amazonka-cloudhsm ^>= 2.0
+        - amazonka-cloudsearch ^>= 2.0
+        - amazonka-cloudsearch-domains ^>= 2.0
+        - amazonka-cloudtrail ^>= 2.0
+        - amazonka-cloudwatch ^>= 2.0
+        - amazonka-cloudwatch-events ^>= 2.0
+        - amazonka-cloudwatch-logs ^>= 2.0
+        - amazonka-codeartifact ^>= 2.0
+        - amazonka-codebuild ^>= 2.0
+        - amazonka-codecommit ^>= 2.0
+        - amazonka-codedeploy ^>= 2.0
+        - amazonka-codeguru-reviewer ^>= 2.0
+        - amazonka-codeguruprofiler ^>= 2.0
+        - amazonka-codepipeline ^>= 2.0
+        - amazonka-codestar-connections ^>= 2.0
+        - amazonka-codestar-notifications ^>= 2.0
+        - amazonka-cognito-identity ^>= 2.0
+        - amazonka-cognito-idp ^>= 2.0
+        - amazonka-cognito-sync ^>= 2.0
+        - amazonka-comprehendmedical ^>= 2.0
+        - amazonka-compute-optimizer ^>= 2.0
+        - amazonka-config ^>= 2.0
+        - amazonka-connect-contact-lens ^>= 2.0
+        - amazonka-connectcampaigns ^>= 2.0
+        - amazonka-connectcases ^>= 2.0
+        - amazonka-connectparticipant ^>= 2.0
+        - amazonka-controltower ^>= 2.0
+        - amazonka-customer-profiles ^>= 2.0
+        - amazonka-databrew ^>= 2.0
+        - amazonka-dataexchange ^>= 2.0
+        - amazonka-datapipeline ^>= 2.0
+        - amazonka-datasync ^>= 2.0
+        - amazonka-detective ^>= 2.0
+        - amazonka-devicefarm ^>= 2.0
+        - amazonka-devops-guru ^>= 2.0
+        - amazonka-directconnect ^>= 2.0
+        - amazonka-discovery ^>= 2.0
+        - amazonka-dlm ^>= 2.0
+        - amazonka-dms ^>= 2.0
+        - amazonka-docdb ^>= 2.0
+        - amazonka-docdb-elastic ^>= 2.0
+        - amazonka-drs ^>= 2.0
+        - amazonka-ds ^>= 2.0
+        - amazonka-dynamodb ^>= 2.0
+        - amazonka-dynamodb-streams ^>= 2.0
+        - amazonka-ebs ^>= 2.0
+        - amazonka-ec2 ^>= 2.0
+        - amazonka-ec2-instance-connect ^>= 2.0
+        - amazonka-ecr ^>= 2.0
+        - amazonka-ecr-public ^>= 2.0
+        - amazonka-ecs ^>= 2.0
+        - amazonka-efs ^>= 2.0
+        - amazonka-eks ^>= 2.0
+        - amazonka-elastic-inference ^>= 2.0
+        - amazonka-elasticache ^>= 2.0
+        - amazonka-elasticbeanstalk ^>= 2.0
+        - amazonka-elasticsearch ^>= 2.0
+        - amazonka-elastictranscoder ^>= 2.0
+        - amazonka-elb ^>= 2.0
+        - amazonka-elbv2 ^>= 2.0
+        - amazonka-emr ^>= 2.0
+        - amazonka-emr-containers ^>= 2.0
+        - amazonka-emr-serverless ^>= 2.0
+        - amazonka-evidently ^>= 2.0
+        - amazonka-finspace ^>= 2.0
+        - amazonka-finspace-data ^>= 2.0
+        - amazonka-fis ^>= 2.0
+        - amazonka-forecast ^>= 2.0
+        - amazonka-forecastquery ^>= 2.0
+        - amazonka-frauddetector ^>= 2.0
+        - amazonka-fsx ^>= 2.0
+        - amazonka-gamelift ^>= 2.0
+        - amazonka-gamesparks ^>= 2.0
+        - amazonka-glacier ^>= 2.0
+        - amazonka-globalaccelerator ^>= 2.0
+        - amazonka-glue ^>= 2.0
+        - amazonka-grafana ^>= 2.0
+        - amazonka-greengrassv2 ^>= 2.0
+        - amazonka-groundstation ^>= 2.0
+        - amazonka-health ^>= 2.0
+        - amazonka-healthlake ^>= 2.0
+        - amazonka-honeycode ^>= 2.0
+        - amazonka-iam ^>= 2.0
+        - amazonka-identitystore ^>= 2.0
+        - amazonka-imagebuilder ^>= 2.0
+        - amazonka-importexport ^>= 2.0
+        - amazonka-inspector ^>= 2.0
+        - amazonka-inspector2 ^>= 2.0
+        - amazonka-iot ^>= 2.0
+        - amazonka-iot-dataplane ^>= 2.0
+        - amazonka-iot-roborunner ^>= 2.0
+        - amazonka-iot1click-devices ^>= 2.0
+        - amazonka-iot1click-projects ^>= 2.0
+        - amazonka-iotdeviceadvisor ^>= 2.0
+        - amazonka-iotevents ^>= 2.0
+        - amazonka-iotevents-data ^>= 2.0
+        - amazonka-iotfleethub ^>= 2.0
+        - amazonka-iotfleetwise ^>= 2.0
+        - amazonka-iotsecuretunneling ^>= 2.0
+        - amazonka-iotsitewise ^>= 2.0
+        - amazonka-iotthingsgraph ^>= 2.0
+        - amazonka-iottwinmaker ^>= 2.0
+        - amazonka-iotwireless ^>= 2.0
+        - amazonka-ivs ^>= 2.0
+        - amazonka-ivschat ^>= 2.0
+        - amazonka-kafka ^>= 2.0
+        - amazonka-kafkaconnect ^>= 2.0
+        - amazonka-kendra ^>= 2.0
+        - amazonka-keyspaces ^>= 2.0
+        - amazonka-kinesis ^>= 2.0
+        - amazonka-kinesis-analytics ^>= 2.0
+        - amazonka-kinesis-firehose ^>= 2.0
+        - amazonka-kinesis-video-signaling ^>= 2.0
+        - amazonka-kinesis-video-webrtc-storage ^>= 2.0
+        - amazonka-kinesisanalyticsv2 ^>= 2.0
+        - amazonka-kms ^>= 2.0
+        - amazonka-lakeformation ^>= 2.0
+        - amazonka-lambda ^>= 2.0
+        - amazonka-lexv2-models ^>= 2.0
+        - amazonka-license-manager ^>= 2.0
+        - amazonka-license-manager-linux-subscriptions ^>= 2.0
+        - amazonka-license-manager-user-subscriptions ^>= 2.0
+        - amazonka-lightsail ^>= 2.0
+        - amazonka-location ^>= 2.0
+        - amazonka-lookoutequipment ^>= 2.0
+        - amazonka-lookoutmetrics ^>= 2.0
+        - amazonka-lookoutvision ^>= 2.0
+        - amazonka-m2 ^>= 2.0
+        - amazonka-macie ^>= 2.0
+        - amazonka-maciev2 ^>= 2.0
+        - amazonka-managedblockchain ^>= 2.0
+        - amazonka-marketplace-analytics ^>= 2.0
+        - amazonka-marketplace-catalog ^>= 2.0
+        - amazonka-marketplace-metering ^>= 2.0
+        - amazonka-mediaconnect ^>= 2.0
+        - amazonka-mediapackage-vod ^>= 2.0
+        - amazonka-mediatailor ^>= 2.0
+        - amazonka-memorydb ^>= 2.0
+        - amazonka-mgn ^>= 2.0
+        - amazonka-migration-hub-refactor-spaces ^>= 2.0
+        - amazonka-migrationhub-config ^>= 2.0
+        - amazonka-migrationhuborchestrator ^>= 2.0
+        - amazonka-migrationhubstrategy ^>= 2.0
+        - amazonka-ml ^>= 2.0
+        - amazonka-mwaa ^>= 2.0
+        - amazonka-neptune ^>= 2.0
+        - amazonka-network-firewall ^>= 2.0
+        - amazonka-networkmanager ^>= 2.0
+        - amazonka-nimble ^>= 2.0
+        - amazonka-oam ^>= 2.0
+        - amazonka-omics ^>= 2.0
+        - amazonka-opensearch ^>= 2.0
+        - amazonka-opensearchserverless ^>= 2.0
+        - amazonka-opsworks ^>= 2.0
+        - amazonka-opsworks-cm ^>= 2.0
+        - amazonka-outposts ^>= 2.0
+        - amazonka-panorama ^>= 2.0
+        - amazonka-personalize ^>= 2.0
+        - amazonka-personalize-events ^>= 2.0
+        - amazonka-personalize-runtime ^>= 2.0
+        - amazonka-pi ^>= 2.0
+        - amazonka-pinpoint ^>= 2.0
+        - amazonka-pinpoint-email ^>= 2.0
+        - amazonka-pinpoint-sms-voice ^>= 2.0
+        - amazonka-pinpoint-sms-voice-v2 ^>= 2.0
+        - amazonka-pipes ^>= 2.0
+        - amazonka-polly ^>= 2.0
+        - amazonka-privatenetworks ^>= 2.0
+        - amazonka-proton ^>= 2.0
+        - amazonka-qldb ^>= 2.0
+        - amazonka-qldb-session ^>= 2.0
+        - amazonka-quicksight ^>= 2.0
+        - amazonka-ram ^>= 2.0
+        - amazonka-rbin ^>= 2.0
+        - amazonka-rds ^>= 2.0
+        - amazonka-rds-data ^>= 2.0
+        - amazonka-redshift ^>= 2.0
+        - amazonka-redshift-data ^>= 2.0
+        - amazonka-redshift-serverless ^>= 2.0
+        - amazonka-rekognition ^>= 2.0
+        - amazonka-resiliencehub ^>= 2.0
+        - amazonka-resource-explorer-v2 ^>= 2.0
+        - amazonka-robomaker ^>= 2.0
+        - amazonka-rolesanywhere ^>= 2.0
+        - amazonka-route53 ^>= 2.0
+        - amazonka-route53-domains ^>= 2.0
+        - amazonka-route53-recovery-cluster ^>= 2.0
+        - amazonka-route53-recovery-control-config ^>= 2.0
+        - amazonka-route53-recovery-readiness ^>= 2.0
+        - amazonka-route53resolver ^>= 2.0
+        - amazonka-rum ^>= 2.0
+        - amazonka-s3 ^>= 2.0
+        - amazonka-s3outposts ^>= 2.0
+        - amazonka-sagemaker-a2i-runtime ^>= 2.0
+        - amazonka-sagemaker-edge ^>= 2.0
+        - amazonka-sagemaker-featurestore-runtime ^>= 2.0
+        - amazonka-sagemaker-geospatial ^>= 2.0
+        - amazonka-sagemaker-metrics ^>= 2.0
+        - amazonka-savingsplans ^>= 2.0
+        - amazonka-scheduler ^>= 2.0
+        - amazonka-schemas ^>= 2.0
+        - amazonka-sdb ^>= 2.0
+        - amazonka-securityhub ^>= 2.0
+        - amazonka-securitylake ^>= 2.0
+        - amazonka-service-quotas ^>= 2.0
+        - amazonka-servicecatalog ^>= 2.0
+        - amazonka-servicecatalog-appregistry ^>= 2.0
+        - amazonka-ses ^>= 2.0
+        - amazonka-sesv2 ^>= 2.0
+        - amazonka-shield ^>= 2.0
+        - amazonka-signer ^>= 2.0
+        - amazonka-simspaceweaver ^>= 2.0
+        - amazonka-sms ^>= 2.0
+        - amazonka-sms-voice ^>= 2.0
+        - amazonka-snow-device-management ^>= 2.0
+        - amazonka-snowball ^>= 2.0
+        - amazonka-sns ^>= 2.0
+        - amazonka-sqs ^>= 2.0
+        - amazonka-ssm ^>= 2.0
+        - amazonka-ssm-contacts ^>= 2.0
+        - amazonka-ssm-incidents ^>= 2.0
+        - amazonka-ssm-sap ^>= 2.0
+        - amazonka-sso ^>= 2.0
+        - amazonka-sso-admin ^>= 2.0
+        - amazonka-sso-oidc ^>= 2.0
+        - amazonka-stepfunctions ^>= 2.0
+        - amazonka-storagegateway ^>= 2.0
+        - amazonka-sts ^>= 2.0
+        - amazonka-support ^>= 2.0
+        - amazonka-support-app ^>= 2.0
+        - amazonka-swf ^>= 2.0
+        - amazonka-synthetics ^>= 2.0
+        - amazonka-textract ^>= 2.0
+        - amazonka-timestream-query ^>= 2.0
+        - amazonka-timestream-write ^>= 2.0
+        - amazonka-transfer ^>= 2.0
+        - amazonka-voice-id ^>= 2.0
+        - amazonka-waf ^>= 2.0
+        - amazonka-wafv2 ^>= 2.0
+        - amazonka-wellarchitected ^>= 2.0
+        - amazonka-wisdom ^>= 2.0
+        - amazonka-worklink ^>= 2.0
+        - amazonka-workmailmessageflow ^>= 2.0
+        - amazonka-workspaces ^>= 2.0
+        - amazonka-workspaces-web ^>= 2.0
+        - amazonka-xray ^>= 2.0
+        # gogol-* disabled due to `gogol-core` due to `servant`: #6089/closed
+        - gogol < 0
+        - gogol-core < 0 # 0.5.0 compile fail
+        - gogol-adexchange-buyer < 0
+        - gogol-adexchange-seller < 0
+        - gogol-admin-datatransfer < 0
+        - gogol-admin-directory < 0
+        - gogol-admin-emailmigration < 0
+        - gogol-admin-reports < 0
+        - gogol-adsense < 0
+        - gogol-adsense-host < 0
+        - gogol-affiliates < 0
+        - gogol-analytics < 0
+        - gogol-android-enterprise < 0
+        - gogol-android-publisher < 0
+        - gogol-appengine < 0
+        - gogol-apps-activity < 0
+        - gogol-apps-calendar < 0
+        - gogol-apps-licensing < 0
+        - gogol-apps-reseller < 0
+        - gogol-apps-tasks < 0
+        - gogol-appstate < 0
+        - gogol-autoscaler < 0
+        - gogol-bigquery < 0
+        - gogol-billing < 0
+        - gogol-blogger < 0
+        - gogol-books < 0
+        - gogol-civicinfo < 0
+        - gogol-classroom < 0
+        - gogol-cloudmonitoring < 0
+        - gogol-cloudtrace < 0
+        - gogol-compute < 0
+        - gogol-container < 0
+        - gogol-customsearch < 0
+        - gogol-dataflow < 0
+        - gogol-dataproc < 0
+        - gogol-datastore < 0
+        - gogol-debugger < 0
+        - gogol-deploymentmanager < 0
+        - gogol-dfareporting < 0
+        - gogol-discovery < 0
+        - gogol-dns < 0
+        - gogol-doubleclick-bids < 0
+        - gogol-doubleclick-search < 0
+        - gogol-drive < 0
+        - gogol-firebase-rules < 0
+        - gogol-fitness < 0
+        - gogol-fonts < 0
+        - gogol-freebasesearch < 0
+        - gogol-fusiontables < 0
+        - gogol-games < 0
+        - gogol-games-configuration < 0
+        - gogol-games-management < 0
+        - gogol-genomics < 0
+        - gogol-gmail < 0
+        - gogol-groups-migration < 0
+        - gogol-groups-settings < 0
+        - gogol-identity-toolkit < 0
+        - gogol-kgsearch < 0
+        - gogol-latencytest < 0
+        - gogol-logging < 0
+        - gogol-maps-coordinate < 0
+        - gogol-maps-engine < 0
+        - gogol-mirror < 0
+        - gogol-monitoring < 0
+        - gogol-oauth2 < 0
+        - gogol-pagespeed < 0
+        - gogol-partners < 0
+        - gogol-people < 0
+        - gogol-play-moviespartner < 0
+        - gogol-plus < 0
+        - gogol-plus-domains < 0
+        - gogol-prediction < 0
+        - gogol-proximitybeacon < 0
+        - gogol-pubsub < 0
+        - gogol-qpxexpress < 0
+        - gogol-replicapool < 0
+        - gogol-replicapool-updater < 0
+        - gogol-resourcemanager < 0
+        - gogol-resourceviews < 0
+        - gogol-script < 0
+        - gogol-sheets < 0
+        - gogol-shopping-content < 0
+        - gogol-siteverification < 0
+        - gogol-spectrum < 0
+        - gogol-sqladmin < 0
+        - gogol-storage < 0
+        - gogol-storage-transfer < 0
+        - gogol-tagmanager < 0
+        - gogol-taskqueue < 0
+        - gogol-translate < 0
+        - gogol-urlshortener < 0
+        - gogol-useraccounts < 0
+        - gogol-vision < 0
+        - gogol-webmaster-tools < 0
+        - gogol-youtube < 0
+        - gogol-youtube-analytics < 0
+        - gogol-youtube-reporting < 0
+        - ede < 0 # 0.3.3.0 compile fail
+        - pagerduty < 0 # 0.0.8 compile fail with GHC 8.4 https://github.com/brendanhay/pagerduty/issues/10
+        - semver ^>= 0.4.0.1
+        - text-manipulate ^>= 0.3.1.0
+
+    "Nick Partridge <nkpart@gmail.com> @nkpart":
+        - cabal-file-th < 0 # 0.2.7 compile fail https://github.com/nkpart/cabal-file-th/issues/13
+
+    "Gershom Bazerman <gershomb@gmail.com> @gbaz":
+        - jmacro ^>= 0.6.18
+        - jmacro-rpc < 0 # 0.3.3 compile fail
+        - jmacro-rpc-snap < 0
+        - jmacro-rpc-happstack < 0
+
+        - mbox < 0
+        - kmeans ^>= 0.1.3
+        - boolsimplifier ^>= 0.1.8
+        - cubicspline ^>= 0.1.2
+        - maximal-cliques ^>= 0.1.1
+
+    "Alexander Bondarenko <aenor.realm@gmail.com> @dpwiz":
+        - hedn ^>= 0.3.0.4
+        - sdl2 ^>= 2.5.5.0
+        - soap < 0
+        - soap-tls < 0
+        - soap-openssl < 0
+
+    "Andres Löh <andres@well-typed.com> @kosmikus":
+        - generics-sop ^>= 0.5.1.3 && <0.5.1.4 # https://github.com/commercialhaskell/stackage/issues/7155
+        - records-sop ^>= 0.1.1.1
+        - sop-core ^>= 0.5.0.2
+
+    "Vivian McPhail <haskell.vivian.mcphail@gmail.com> @amcphail":
+        - hmatrix-gsl-stats ^>= 0.4.1.8
+        - hsignal ^>= 0.2.7.5
+        - hstatistics ^>= 0.3.1
+        - plot < 0 # 0.2.3.11 # fails to compile (#7017)
+        - vector-buffer ^>= 0.4.1
+        - hmatrix-repa < 0
+
+    "Noam Lewis <jones.noamle@gmail.com> @sinelaw":
+        - xml-to-json < 0
+        - xml-to-json-fast ^>= 2.0.0
+        - wl-pprint ^>= 1.2.1
+        # not a maintainer
+        - hxt-curl ^>= 9.1.1.1
+        - hxt-expat ^>= 9.1.1
+        - hxt-tagsoup ^>= 9.1.4
+        - hexpat ^>= 0.20.13
+        - digits ^>= 0.3.1
+        - logict ^>= 0.8.1.0
+        - leveldb-haskell ^>= 0.6.5
+        - system-argv0 ^>= 0.1.1
+        - markdown-unlit ^>= 0.6.0
+
+    "Brian McKenna <brian@brianmckenna.org> @puffnfresh":
+        - jwt ^>= 0.11.0
+
+    "Sven Bartscher sven.bartscher@weltraumschlangen.de @kritzefitz":
+        - setlocale ^>= 1.0.0.10
+
+    "Taylor Fausak <taylor@fausak.me> @tfausak":
+        - autoexporter ^>= 2.0.0.9
+        - burrito ^>= 2.0.1.7
+        - flow ^>= 2.0.0.4
+        - github-release ^>= 2.0.0.9
+        - json-feed ^>= 2.0.0.10
+        - lackey ^>= 2.0.0.7
+        - patrol ^>= 1.0.0.6
+        - rampart ^>= 2.0.0.7
+        - ratel ^>= 2.0.0.10
+        - ratel-wai ^>= 2.0.0.5
+        - rattletrap ^>= 12.1.2
+        - salve ^>= 2.0.0.4
+        - strive ^>= 6.0.0.10
+        - witch ^>= 1.2.0.3
+        - wuss ^>= 2.0.1.5
+
+        - bmp ^>= 1.2.6.3 # @benl23x5
+        - gpolyline ^>= 0.1.0.1 # @fegu
+
+    "Marios Titas <redneb@gmx.com> @redneb":
+        - HsOpenSSL-x509-system ^>= 0.1.0.4
+        - adler32 ^>= 0.1.2.0
+        - btrfs ^>= 0.2.1.0
+        - disk-free-space ^>= 0.1.0.1
+        - hxt-css ^>= 0.1.0.3
+        - islink ^>= 0.1.0.0
+        - linux-file-extents ^>= 0.2.0.1
+        - linux-namespaces ^>= 0.1.3.1
+
+    "Will Coster <willcoster@gmail.com> @fimad":
+        - prometheus-client ^>= 1.1.1
+        - prometheus-metrics-ghc ^>= 1.0.1.2
+        - scalpel ^>= 0.6.2.2
+        - scalpel-core ^>= 0.6.2.2
+        - wai-middleware-prometheus ^>= 1.0.0.1
+
+    "William Casarin <bill@casarin.me> @jb55":
+        - bson-lens ^>= 0.1.1
+        - cased ^>= 0.1.0.0
+        - elm-export ^>= 0.6.0.1
+        - elm-export-persistent < 0
+        - pipes-csv ^>= 1.4.3
+        - pipes-mongodb ^>= 0.1.0.0
+        - servant-elm ^>= 0.7.3
+        - servant-streaming < 0
+        - servant-streaming-client < 0
+        - servant-streaming-server < 0
+        - skeletons < 0
+
+    "David Raymond Christiansen <david@davidchristiansen.dk> @david-christiansen":
+        - annotated-wl-pprint ^>= 0.7.0
+
+    "Yitz Gale <gale@sefer.org> @ygale":
+        - boolean-normal-forms < 0
+        - strict-concurrency ^>= 0.2.4.3
+        - timezone-series ^>= 0.1.13
+        - timezone-olson ^>= 0.2.1
+
+    "Harry Garrood <harry@garrood.me> @hdgarrood":
+        - aeson-better-errors < 0
+
+    "Mitchell Rosen <mitchellwrosen@gmail.com> @mitchellwrosen":
+        - hasql-interpolate ^>= 0.2.1.0
+        - hasql-listen-notify ^>= 0.1.0
+        - int-supply ^>= 1.0.0
+        - ki ^>= 1.0.1.1
+        - ki-unlifted ^>= 1.0.0.2
+        - list-shuffle ^>= 1.0.0
+        - park-bench ^>= 0.1.1.0
+        - tasty-hspec ^>= 1.2.0.4
+        - termbox ^>= 2.0.0.1
+        - termbox-banana ^>= 2.0.0
+        - termbox-bindings-c ^>= 0.1.0.1
+        - termbox-bindings-hs ^>= 1.0.0
+        - termbox-tea ^>= 1.0.0
+        - text-ansi ^>= 0.3.0.1
+        - timer-wheel ^>= 1.0.0
+
+    "QBayLogic B.V. <devops@qbaylogic.com> @martijnbastiaan":
+        - ghc-tcplugins-extra ^>= 0.4.5
+        - ghc-typelits-extra ^>= 0.4.6
+        - ghc-typelits-knownnat ^>= 0.7.10
+        - ghc-typelits-natnormalise ^>= 0.7.9
+        - clash-prelude ^>= 1.8.1
+        # - clash-lib              # https://github.com/commercialhaskell/stackage/issues/7176
+        # - clash-ghc              # https://github.com/commercialhaskell/stackage/issues/7176
+
+    "Martijn Bastiaan <martijn@hmbastiaan.nl> @martijnbastiaan":
+        - aeson-pretty ^>= 0.8.10
+        - doctest-parallel ^>= 0.3.1
+
+    "Athan Clark <athan.clark@gmail.com> @athanclark":
+        - aeson-attoparsec ^>= 0.0.0
+        - alternative-vector ^>= 0.0.0
+        - almost-fix ^>= 0.0.2
+        - attoparsec-base64 ^>= 0.0.0
+        - attoparsec-path ^>= 0.0.0.1
+        # - attoparsec-ip # Deprecated in favor of ip
+        - attoparsec-uri ^>= 0.0.9
+        - chan ^>= 0.0.4.1
+        - commutative ^>= 0.0.2
+        - composition-extra ^>= 2.1.0
+        - every ^>= 0.0.1
+        - extractable-singleton ^>= 0.0.1
+        - follow-file < 0 # 0.0.3 compile fail https://github.com/athanclark/follow-file/issues/1
+        - HSet ^>= 0.0.2
+        - markup < 0 # 4.2.0 compile fail https://github.com/athanclark/markup/issues/7
+        - monad-control-aligned ^>= 0.0.2.1
+        - monadoid ^>= 0.0.3
+        - n-tuple ^>= 0.0.3
+        - path-extra ^>= 0.3.1
+        - pred-set ^>= 0.0.1
+        - pred-trie < 0
+        - poly-arity ^>= 0.1.0
+        - quickcheck-combinators < 0
+        - rose-trees < 0
+        - sets < 0
+        - since ^>= 0.0.0
+        - timemap < 0
+        - tmapchan ^>= 0.0.3
+        - tmapmvar ^>= 0.0.4
+        - tries < 0
+        - unit-constraint ^>= 0.0.0
+        - unfoldable-restricted < 0
+        - urlpath ^>= 11.0.2
+        - wai-transformers ^>= 0.1.0
+        - websockets-rpc < 0
+        - websockets-simple ^>= 0.2.0
+        - webpage ^>= 0.0.5.1
+        - ws ^>= 0.0.6
+
+    "Fumiaki Kinoshita <fumiexcel@gmail.com> @fumieval":
+        - boundingboxes ^>= 0.2.3
+        - control-bool ^>= 0.2.1
+        - drinkery < 0
+        - monad-skeleton < 0
+        - xml-lens ^>= 0.3.1
+        - witherable ^>= 0.4.2
+        - deriving-aeson ^>= 0.2.9
+        - data-functor-logistic ^>= 0.0
+
+    "Peter Harpending <peter@harpending.org> @pharpend":
+        - editor-open ^>= 0.6.0.0
+        - exceptional < 0 # 0.3.0.0 MonadFail
+        - pager ^>= 0.1.1.0
+        - semiring-simple ^>= 1.0.0.1
+
+    "Philipp Hausmann <ph_git@314.ch> @phile314":
+        - language-thrift < 0
+
+    "Michael Thompson <what_is_it_to_do_anything@yahoo.com> @michaelt":
+        - pipes-text ^>= 1.0.1
+        - lens-simple < 0
+        - lens-family-core ^>= 2.1.2
+        - lens-family ^>= 2.1.2
+
+    "Sjoerd Visscher @sjoerdvisscher":
+        - one-liner ^>= 2.1
+
+    "Justin Le <justin@jle.im> @mstksg":
+        - advent-of-code-api < 0 # 0.2.8.4 compile fail https://github.com/commercialhaskell/stackage/issues/7038
+        - auto < 0
+        - backprop ^>= 0.2.6.5
+        - bins < 0
+        - conduino < 0 # 0.2.2.0 https://github.com/mstksg/conduino/issues/1
+        - configurator-export ^>= 0.1.0.1
+        - decidable < 0
+        - emd < 0
+        - functor-products < 0
+        - hamilton < 0 # 0.1.0.3 compile fail https://github.com/mstksg/hamilton/issues/9
+        - hmatrix-backprop ^>= 0.1.3.0
+        - hmatrix-vector-sized ^>= 0.1.3.0
+        - lens-typelevel < 0
+        - list-witnesses < 0
+        - nonempty-containers ^>= 0.3.4.5
+        - one-liner-instances ^>= 0.1.3.0
+        - prompt < 0 # 0.1.1.2 # fails to compile (#7017)
+        - servant-cli < 0
+        - tagged-binary ^>= 0.2.0.1
+        - type-combinators-singletons < 0
+        - typelits-witnesses ^>= 0.4.0.1
+        - uncertain < 0
+        - vector-sized ^>= 1.5.0
+
+    "Ian Duncan <ian@iankduncan.com> @iand675":
+        - feature-flags ^>= 0.1.0.1
+        - metrics ^>= 0.4.1.1
+        - pipes-wai ^>= 3.2.0
+        - serf < 0
+        - uri-templater < 0
+        - data-sketches ^>= 0.3.1.0
+        - data-sketches-core ^>= 0.1.0.0
+
+    "Michael Xavier <michael@michaelxavier.net> @MichaelXavier":
+        - uri-bytestring ^>= 0.3.3.1
+        - cron < 0 # 0.7.0 ghc-9.6 https://github.com/MichaelXavier/cron/issues/50
+        - tasty-tap ^>= 0.1.0
+        - tasty-fail-fast ^>= 0.0.3
+        - drifter ^>= 0.3.0
+        - drifter-postgresql ^>= 0.2.1
+        - drifter-sqlite ^>= 0.1.0.0
+
+    "Lars Kuhtz <lakuhtz@gmail.com> @larskuhtz":
+        - wai-cors ^>= 0.2.7
+        - configuration-tools ^>= 0.7.0
+        - random-bytestring ^>= 0.1.4
+
+    "Sam Rijs <srijs@airpost.net> @srijs":
+        - ndjson-conduit ^>= 0.1.0.5
+        - operational-class < 0 # 0.3.0.0 compile fail https://github.com/srijs/haskell-operational-class/issues/1
+        - result ^>= 0.2.6.0
+
+    "Daniel Patterson <dbp@dbpmail.net> @dbp":
+        - hworker ^>= 0.1.0.1
+        - fn ^>= 0.3.0.2
+
+    "Mathieu Boespflug <mboes@tweag.net> @mboes":
+        - choice ^>= 0.2.3
+        - distributed-closure ^>= 0.5.0.0
+        - inline-java < 0
+        - inline-r ^>= 1.0.1
+        - jni < 0 # 0.8.0 compile fail
+        - jvm < 0
+        - jvm-streaming < 0
+        - H ^>= 1.0.0
+        - sparkle < 0
+        - th-lift ^>= 0.8.4
+
+    "Christopher Reichert <creichert07@gmail.com> @creichert":
+        - bencode ^>= 0.6.1.1
+        - hsebaysdk < 0
+        - dockerfile ^>= 0.2.0
+        - wai-middleware-throttle ^>= 0.3.0.1
+        - yesod-auth-basic ^>= 0.1.0.3
+
+    "Hirotomo Moriwaki <philopon.dependence@gmail.com> @philopon":
+        - barrier ^>= 0.1.1
+
+    "Kai Zhang <kai@kzhang.org> @kaizhang":
+        - matrices ^>= 0.5.0
+        - haskell-igraph < 0 # 0.8.0 compile fail ghc 8.10.1 #5440/closed
+
+    "Michel Boucey <michel.boucey@gmail.com> @MichelBoucey":
+        - IPv6Addr ^>= 2.0.5.1
+        - ip6addr ^>= 1.0.3
+        - cayley-client < 0
+        - Spintax < 0
+        - glabrous ^>= 2.0.6.2
+        - google-oauth2-jwt < 0
+        - IPv6DB < 0
+        - gothic < 0
+        - NanoID < 0
+
+    "koral koral@mailoo.org @k0ral":
+        - atom-conduit ^>= 0.9.0.1
+        - conduit-parse ^>= 0.2.1.1
+        - dublincore-xml-conduit ^>= 0.1.0.3
+        - euler-tour-tree < 0
+        - opml-conduit ^>= 0.9.0.0
+        - rss-conduit ^>= 0.6.0.1
+        - timerep ^>= 2.1.0.0
+        - xml-conduit-parse < 0
+
+    "Daniel Cartwright <chessai1996@gmail.com> @chessai":
+        - streaming ^>= 0.2.4.0
+        - streaming-bytestring ^>= 0.3.2
+        - country ^>= 0.2.4.1
+        - semirings ^>= 0.6
+        - torsor ^>= 0.1
+        - chronos ^>= 1.1.5.1
+        - refined ^>= 0.8.1
+        - these-skinny ^>= 0.7.5
+        - hedgehog-classes ^>= 0.2.5.4
+
+    "Kostiantyn Rybnikov <k-bx@k-bx.com> @k-bx":
+        - SHA ^>= 1.6.4.4
+        - currency ^>= 0.2.0.0
+        - data-ordlist ^>= 0.4.7.0
+        - digits ^>= 0.3.1
+        - dns ^>= 4.2.0
+        - friday ^>= 0.2.3.2
+        - friday-juicypixels ^>= 0.1.2.4
+        - hbeanstalk < 0
+        - hedis ^>= 0.15.2
+        - hprotoc < 0
+        - hsyslog-udp < 0
+        - iso3166-country-codes ^>= 0.20140203.8
+        - iso639 ^>= 0.1.0.3
+        - monoidal-containers ^>= 0.6.4.0
+        - murmur-hash ^>= 0.1.0.10
+        - protocol-buffers < 0
+        - protocol-buffers-descriptor < 0
+        - regex-pcre ^>= 0.95.0.0
+        - string-class ^>= 0.1.7.1
+        - string-combinators ^>= 0.6.0.5
+
+    "Rob O'Callahan ropoctl@gmail.com @rcallahan":
+        - pipes-fastx ^>= 0.3.0.0
+        - seqalign ^>= 0.2.0.4
+
+    "John Lenz <wuzzeb@gmail.com> @wuzzeb":
+        - yesod-static-angular < 0
+        - hspec-webdriver ^>= 1.2.2
+        - webdriver-angular < 0
+
+    "Sven Heyll <svh@posteo.de> @sheyll":
+        - b9 < 0
+        - type-spec ^>= 0.4.0.0
+        - pretty-types < 0 # 0.4.0.0 # fails to compile https://github.com/sheyll/pretty-types/issues/2
+        - function-builder ^>= 0.3.0.1
+        - bytestring-to-vector ^>= 0.3.0.1
+
+    "Jakub Fijałkowski <kuba@codinginfinity.me> @jakubfijalkowski":
+        - hlibsass ^>= 0.1.10.1
+        - hsass ^>= 0.8.0
+
+    "Robert Massaioli <robertmassaioli@gmail.com> @robertmassaioli":
+        - range ^>= 0.3.0.2
+
+    "Vladislav Zavialov <vlad.z.4096@gmail.com> @int-index":
+        - transformers-lift < 0
+        - union < 0
+        - named ^>= 0.3.0.1
+        - inj ^>= 1.0
+        - shower < 0
+
+    "Stack Builders stackage@stackbuilders.com @stackbuilders":
+        - atomic-write ^>= 0.2.0.7
+        - dbcleaner ^>= 0.1.3
+        - dotenv ^>= 0.11.0.2
+        - hapistrano < 0
+        - hspec-golden ^>= 0.2.1.0
+        - inflections ^>= 0.4.0.7
+        - stache ^>= 2.3.4
+        - scalendar < 0
+
+    "Sergey Alirzaev <zl29ah@gmail.com> @l29ah":
+        - monad-peel ^>= 0.3
+        - NineP ^>= 0.0.2.1
+        - Network-NineP < 0
+        - pontarius-xmpp ^>= 0.5.6.8
+        - stringprep ^>= 1.0.0
+        - ranges ^>= 0.2.4
+
+    "Antoni Silvestre <antoni.silvestre@gmail.com> @asilvestre":
+        # Test suite needs a running neo4j server with auth disabled
+        # unfortunately the cabal package name and the github repo don't have the exact same name
+        # package name is haskell-neo4j-client github name is haskell-neo4j-rest-client
+        - haskell-neo4j-client < 0 # 0.3.2.4 compile fail with GHC 8.4 https://github.com/asilvestre/haskell-neo4j-rest-client/issues/32
+
+    "Anton Kholomiov <anton.kholomiov@gmail.com>":
+        - data-fix ^>= 0.3.2
+
+    "Alexey Khudyakov <alexey.skladnoy@gmail.com> @Shimuuar":
+        - histogram-fill ^>= 0.9.1.0
+        - fixed-vector ^>= 1.2.3.0
+        - fixed-vector-hetero ^>= 0.6.1.1
+        - type-level-numbers ^>= 0.1.1.2
+
+    "Ryan Scott <ryan.gl.scott@gmail.com> @RyanGlScott":
+        - abstract-deque ^>= 0.3
+        - abstract-deque-tests ^>= 0.3
+        - abstract-par ^>= 0.3.3
+        - atomic-primops ^>= 0.8.4
+        - base-compat-batteries ^>= 0.13.1
+        - base-orphans ^>= 0.9.1
+        - bifunctor-classes-compat ^>= 0.1
+        - chaselev-deque < 0
+        - code-page ^>= 0.2.1
+        - constraint-tuples ^>= 0.1.2
+        - criterion ^>= 1.6.3.0
+        - criterion-measurement ^>= 0.2.1.0
+        - data-reify ^>= 0.6.3
+        - deriving-compat ^>= 0.6.5
+        - dotgen ^>= 0.4.3
+        - echo ^>= 0.1.4
+        - eliminators ^>= 0.9.3
+        - foldable1-classes-compat ^>= 0.1
+        - generic-deriving ^>= 1.14.5
+        - ghc-bignum-orphans ^>= 0.1.1
+        - hashmap ^>= 1.3.3
+        - indexed-traversable-instances ^>= 0.1.1.2
+        - invariant ^>= 0.6.2
+        - keycode ^>= 0.2.2
+        - lift-generics ^>= 0.2.1
+        - mintty ^>= 0.1.4
+        - monad-par ^>= 0.3.6
+        - monad-par-extras ^>= 0.3.3
+        - mtl-compat ^>= 0.2.2
+        - ordered-containers ^>= 0.2.3
+        - proxied ^>= 0.3.1
+        - rdtsc ^>= 1.3.0.1
+        - singleton-nats ^>= 0.4.7
+        - singletons-base ^>= 3.2
+        - singletons-th ^>= 3.2
+        - text-show ^>= 3.10.4
+        - text-show-instances ^>= 3.9.7
+        - th-abstraction ^>= 0.5.0.0
+        - th-compat ^>= 0.1.4
+        - thread-local-storage ^>= 0.2
+        - type-equality ^>= 1
+
+    "Kirill Zaborsky <qrilka@gmail.com> @qrilka":
+        - xlsx ^>= 1.1.1
+
+    "Matt Parsons <parsonsmatt@gmail.com> @parsonsmatt":
+        - annotated-exception ^>= 0.2.0.5
+        - monad-logger-prefix < 0
+        - monad-metrics ^>= 0.2.2.1
+        - prairie < 0
+        - ekg-cloudwatch < 0 # 0.0.1.6 fails to compile we amazonka 2.0
+        - smtp-mail < 0
+        - liboath-hs ^>= 0.0.1.2
+        - servant-quickcheck < 0
+        - esqueleto ^>= 3.5.11.0
+        - hedgehog-fakedata < 0
+        - persistent-discover ^>= 0.1.0.7
+        - persistent-documentation < 0 # 0.1.0.4 https://github.com/lumihq/persistent-documentation/issues/11
+        - persistent-typed-db ^>= 0.1.0.7
+        - persistent-qq ^>= 2.12.0.6
+        - persistent-pagination ^>= 0.1.1.2
+        - hspec-hedgehog ^>= 0.1.1.0
+        - exception-via ^>= 0.2.0.0
+        - record-wrangler < 0
+        - lift-type ^>= 0.1.1.1
+        - some-dict-of ^>= 0.1.0.2
+        - discover-instances ^>= 0.1.0.0
+
+    "Matthew Pickering <matthewtpickering@gmail.com> @mpickering":
+        - refact ^>= 0.3.0.2
+
+    "Andrew Gibiansky <andrew.gibiansky@gmail.com> @gibiansky":
+        - ipython-kernel ^>= 0.11.0.0
+
+    "James Cook <mokus@deepbondi.net> @mokus0":
+        - dependent-map ^>= 0.4.0.0
+        - dependent-sum ^>= 0.7.2.0
+        - dependent-sum-template ^>= 0.1.1.1
+        - dice ^>= 0.1.1
+        - hstatsd < 0
+        - misfortune ^>= 0.1.2.1
+
+    "Timo von Holtz <tvh@tvholtz.de> @tvh":
+        - ekg-wai < 0
+        - haxl-amazonka < 0
+        - hasql-migration ^>= 0.3.0
+        - servant-JuicyPixels ^>= 0.3.1.1
+
+    "Steven Fontanella <steven.fontanella@gmail.com> @stevenfontanella":
+        - microlens ^>= 0.4.13.1
+        - microlens-platform ^>= 0.4.3.4
+        - microlens-mtl ^>= 0.2.0.3
+        - microlens-th ^>= 0.4.3.14
+        - microlens-ghc ^>= 0.4.14.2
+        - microlens-contra ^>= 0.1.0.3
+
+    "Takano Akio tak@anoak.io @takano-akio":
+        - fast-builder < 0
+        - filelock ^>= 0.1.1.7
+
+    "Brian Lewis brian@lorf.org @bsl":
+        - bindings-GLFW ^>= 3.3.2.0
+        - GLFW-b ^>= 3.3.0.0
+
+    "Niklas Hambüchen mail@nh2.me @nh2":
+        - conduit-concurrent-map ^>= 0.1.3
+        - hidapi ^>= 0.1.8
+        - iso8601-time ^>= 0.1.5
+        - loop ^>= 0.3.0
+        - lz4-frame-conduit ^>= 0.1.0.1
+        - netpbm ^>= 1.0.4
+        - network-house < 0 # 0.1.0.2 compile failure MonadFail
+        - reinterpret-cast ^>= 0.1.0
+        - shared-memory ^>= 0.2.0.1
+        - posix-paths ^>= 0.3.0.0
+        # As dependencies of packages above
+        - attoparsec-binary ^>= 0.2
+
+    "Michael Walker <mike@barrucadu.co.uk> @barrucadu":
+        - both < 0
+        - concurrency ^>= 1.11.0.3
+        - dejafu ^>= 2.4.0.5
+        - hunit-dejafu ^>= 2.0.0.6
+        - tasty-dejafu ^>= 2.1.0.1
+        - irc-ctcp ^>= 0.1.3.1
+        - irc-conduit < 0
+        - irc-client < 0
+
+    "Rudy Matela <rudy@matela.com.br> @rudymatela":
+        - leancheck ^>= 1.0.0
+        - leancheck-instances ^>= 0.0.5
+        - fitspec ^>= 0.4.10
+        - express ^>= 1.0.12
+        - speculate ^>= 0.4.14
+        - extrapolate ^>= 0.4.6
+        - code-conjure ^>= 0.5.6
+        - percent-format ^>= 0.0.4
+        - tasty-leancheck ^>= 0.0.2
+        - hspec-leancheck ^>= 0.0.6
+        - test-framework-leancheck ^>= 0.0.4
+
+    "Trevor Elliott <awesomelyawesome@gmail.com> @elliottt":
+        - irc ^>= 0.6.1.1
+
+    "Dennis Gosnell <cdep.illabout@gmail.com> @cdepillabout":
+        - envelope ^>= 0.2.2.0
+        - from-sum ^>= 0.2.3.0
+        - natural-transformation ^>= 0.4
+        - password ^>= 3.0.2.1
+        - password-instances ^>= 3.0.0.0
+        - password-types ^>= 1.0.0.0
+        - pretty-simple ^>= 4.1.2.0
+        - print-console-colors ^>= 0.1.0.0
+        - read-env-var ^>= 1.0.0.0
+        - servant-checked-exceptions ^>= 2.2.0.1
+        - servant-checked-exceptions-core ^>= 2.2.0.1
+        - servant-rawm ^>= 1.0.0.0
+        - servant-static-th ^>= 1.0.0.0
+        - termonad ^>= 4.5.0.0
+        - world-peace ^>= 1.0.2.0
+        - xml-html-qq ^>= 0.1.0.1
+        - xml-indexed-cursor ^>= 0.1.1.0
+
+    "Franklin Chen <franklinchen@franklinchen.com> @FranklinChen":
+        - Ebnf2ps ^>= 1.0.15
+
+    "Tobias Bexelius <tobias_bexelius@hotmail.com> @tobbebex":
+        - GPipe < 0
+
+    "Jonas Carpay <jonascarpay@gmail.com> @jonascarpay":
+        - apecs ^>= 0.9.5
+        - apecs-gloss ^>= 0.2.4
+        - apecs-physics ^>= 0.4.6
+        - aeson-commit < 0
+        - calligraphy ^>= 0.1.6
+        - js-chart ^>= 2.9.4.1
+        - safe-gen ^>= 1.0.1
+        - tasty-focus ^>= 1.0.1
+
+    "Spencer Janssen <spencerjanssen@gmail.com> @spencerjanssen":
+        - Xauth ^>= 0.1
+
+    "Sebastian de Bellefon <arnaudpourseb@gmail.com> @Helkafen":
+        - wai-middleware-metrics ^>= 0.2.4
+
+    "Gregory Collins <greg@gregorycollins.net> @gregorycollins":
+        - hashtables ^>= 1.3.1
+        - io-streams ^>= 1.5.2.2
+        - openssl-streams ^>= 1.2.3.0
+
+    "Andrew Cowie <istathar@gmail.com> @istathar":
+        - chronologique ^>= 0.3.1.3
+        - http-common ^>= 0.8.3.4
+        - http-streams ^>= 0.8.9.9
+        - locators ^>= 0.3.0.3
+        - core-data ^>= 0.3.9.1
+        - core-program ^>= 0.7.0.0
+        - core-telemetry ^>= 0.2.9.4
+        - core-text ^>= 0.3.8.1
+
+    "Sean Hunt <scshunt@csclub.uwaterloo.ca @scshunt":
+        - cheapskate < 0
+
+    "Ivan Miljenovic <Ivan.Miljenovic@gmail.com> @ivan-m":
+        - fgl ^>= 5.8.2.0
+        - wl-pprint-text ^>= 1.2.0.2
+        - servant-pandoc < 0
+
+    "Sharif Olorin <sio@tesser.org> @olorin":
+        - quickcheck-text ^>= 0.1.2.1
+        - nagios-check ^>= 0.3.2
+
+    "Peter Simons <simons@cryp.to> @peti":
+        - cabal2spec ^>= 2.7.0
+        - cgi ^>= 3001.5.0.1
+        - distribution-nixpkgs ^>= 1.7.0.1
+        - distribution-opensuse ^>= 1.1.4
+        - flexible-defaults ^>= 0.0.3
+        - funcmp ^>= 1.9
+        - hackage-db ^>= 2.1.3
+        - hledger-interest ^>= 1.6.6
+        - hopenssl ^>= 2.2.5
+        - hsdns ^>= 1.8
+        - hsemail ^>= 2.2.1
+        - hsyslog ^>= 5.0.2
+        - jailbreak-cabal ^>= 1.4
+        - lambdabot-core ^>= 5.3.1.2
+        - lambdabot-irc-plugins ^>= 5.3.1.2
+        - language-nix ^>= 2.2.0
+        - logging-facade-syslog ^>= 1
+        - MonadPrompt ^>= 1.0.0.5
+        - nix-paths ^>= 1.0.1
+        - parsec-class ^>= 1.0.0.0
+        - prim-uniq ^>= 0.2
+        - random-fu ^>= 0.3.0.1
+        - random-source < 0
+        - rvar ^>= 0.3.0.2
+        - SafeSemaphore ^>= 0.10.1
+        - streamproc < 0
+        - stringsearch ^>= 0.3.6.6 # for cgi
+        - titlecase ^>= 1.0.1
+
+    "Mark Fine <mark.fine@gmail.com> @markfine":
+        - postgresql-schema ^>= 0.1.14
+        - sbp ^>= 5.0.4
+
+    "Jinjing Wang <nfjinjing@gmail.com> @nfjinjing":
+        - moesocks < 0
+
+    "Gregory W. Schwartz <gregory.schwartz@drexel.edu> @GregorySchwartz":
+        - diversity ^>= 0.8.1.0
+        - fasta ^>= 0.10.4.2
+        - modify-fasta < 0
+        - tree-fun ^>= 0.8.1.0
+        - random-tree ^>= 0.6.0.5
+        - clumpiness ^>= 0.17.0.2
+
+    "Simon Marechal <bartavelle@gmail.com> @bartavelle":
+        - compactmap ^>= 0.1.4.3
+        - stateWriter ^>= 0.4.0
+        - filecache < 0
+        - pcre-utils ^>= 0.1.9
+        - strict-base-types ^>= 0.8
+        - withdependencies ^>= 0.3.0
+        - hruby ^>= 0.5.1.0
+        - language-puppet < 0
+        - tar-conduit ^>= 0.4.0
+
+    "Mark Karpov <markkarpov92@gmail.com> @mrkkrp":
+        - JuicyPixels-extra ^>= 0.6.0
+        - cue-sheet ^>= 2.0.2
+        - flac ^>= 0.2.1
+        - flac-picture ^>= 0.1.2
+        - forma ^>= 1.2.0
+        - ghc-syntax-highlighter ^>= 0.0.10.0 && <0.0.11.0 # https://github.com/commercialhaskell/stackage/issues/7154
+        - hspec-megaparsec ^>= 2.2.1
+        - htaglib ^>= 1.2.1
+        - html-entity-map ^>= 0.1.0.0
+        - identicon ^>= 0.2.2
+        - lame ^>= 0.2.2
+        - megaparsec ^>= 9.5.0
+        - megaparsec-tests ^>= 9.5.0
+        - mmark ^>= 0.0.7.6
+        - mmark-cli ^>= 0.0.5.1
+        - mmark-ext ^>= 0.2.1.5
+        - modern-uri ^>= 0.3.6.1
+        - ormolu ^>= 0.7.2.0
+        - pagination ^>= 0.2.2
+        - parser-combinators ^>= 1.3.0
+        - parser-combinators-tests ^>= 1.3.0
+        - path ^>= 0.9.5
+        - path-io ^>= 1.8.1
+        - req ^>= 3.13.1
+        - req-conduit ^>= 1.0.1
+        - stache ^>= 2.3.4
+        - tagged-identity ^>= 0.1.4
+        - text-metrics ^>= 0.3.2
+        - wave ^>= 0.2.1
+        - zip ^>= 2.0.0
+
+    "Emmanuel Touzery <etouzery@gmail.com> @emmanueltouzery":
+        - app-settings < 0
+        - hsexif ^>= 0.6.1.10
+        - slack-web < 0
+
+    "Nickolay Kudasov <nickolay.kudasov@gmail.com> @fizruk":
+        - http-api-data ^>= 0.5.1
+        - swagger2 ^>= 2.8.7
+        - telegram-bot-simple < 0
+        - rzk ^>= 0.7.1
+
+    "Jared Tobin <jared@jtobin.ca> @jtobin":
+        - mwc-probability ^>= 2.3.1
+        - mcmc-types ^>= 1.0.3
+        - mighty-metropolis ^>= 2.0.0
+        - speedy-slice ^>= 0.3.2
+        - hasty-hamiltonian ^>= 1.3.4
+        - declarative ^>= 0.5.4
+        - sampling ^>= 0.3.5
+        - flat-mcmc < 0
+        - urbit-hob < 0
+        - hnock < 0
+
+    "Facundo Domínguez <facundo.dominguez@tweag.io> @facundominguez":
+        - inline-c ^>= 0.9.1.10
+        - jvm-batching < 0
+        - pthread ^>= 0.2.1
+
+    "Dave Tapley <dukedave@gmail.com> @dukedave":
+        - inline-c-cpp ^>= 0.5.0.2
+
+    "Takahiro Himura <himuratk421@gmail.com> @himura":
+        - lens-regex ^>= 0.1.3
+        - twitter-conduit ^>= 0.6.1
+        - twitter-types ^>= 0.11.0
+        - twitter-types-lens ^>= 0.11.0
+
+    "Robbin C. <robbinch33@gmail.com> @robbinch":
+        - zim-parser ^>= 0.2.1.0
+
+    "David Wiltshire <david.wiltshire@metark.com> @dave77":
+        # on behalf of Alexey Karakulov @w3rs
+        - hashable-time < 0
+
+    "Yuras Shumovich <shumovichy@gmail.com> @Yuras":
+        - pdf-toolbox-content ^>= 0.1.1
+        - pdf-toolbox-core ^>= 0.1.1
+        - pdf-toolbox-document ^>= 0.1.2
+        - io-region ^>= 0.1.1
+        - scanner ^>= 0.3.1
+
+    "Stanislav Chernichkin <schernichkin@gmail.com> @schernichkin":
+        - partial-isomorphisms ^>= 0.2.3.0
+
+    "Christoph Breitkopf <chbreitkopf@gmail.com> @bokesan":
+        - IntervalMap ^>= 0.6.2.1
+
+    "Michele Lacchia <michelelacchia@gmail.com> @rubik":
+        - pathwalk ^>= 0.3.1.2
+
+    "John Galt <jgalt@centromere.net> @centromere":
+        - cacophony ^>= 0.10.1
+        - blake2 ^>= 0.3.0.1
+        - nfc ^>= 0.1.1
+
+
+    "Michael Schröder <mc.schroeder@gmail.com> @mcschroeder":
+        - ctrie ^>= 0.2
+        - ttrie ^>= 0.1.2.2
+
+    "Stefan Kersten <kaoskorobase@gmail.com> @kaoskorobase":
+        - hsndfile ^>= 0.8.0
+        - hsndfile-vector ^>= 0.5.2
+
+    "yihuang <yi.codeplayer@gmail.com> @yihuang":
+        - tagstream-conduit ^>= 0.5.6
+
+    "Johannes Hilden <hildenjohannes@gmail.com> @laserpants":
+        - hashids ^>= 1.1.0.1
+        - fuzzyset ^>= 0.3.1
+        - sqids ^>= 0.2.0.0
+
+    "Will Sewell <me@willsewell.com> @willsewell":
+        - benchpress ^>= 0.2.2.23
+        - pusher-http-haskell ^>= 2.1.0.17
+
+    "Yorick Laupa yo.eight@gmail.com @YoEight":
+        - eventstore < 0 # 1.4.3 https://github.com/commercialhaskell/stackage/issues/7075
+        - dotnet-timespan ^>= 0.0.1.0
+        - eventsource-api < 0
+        - eventsource-geteventstore-store < 0
+        - eventsource-store-specs < 0
+        - eventsource-stub-store < 0
+
+    "Sebastian Dröge slomo@coaxion.net @sdroege":
+        - conduit-iconv < 0 # 0.1.1.3 compile fail MonadFail
+        - conduit-connection < 0
+
+    "Andrew Rademacher <andrewrademacher@gmail.com> @AndrewRademacher":
+        - aeson-casing ^>= 0.2.0.0
+        - graylog < 0 # 0.1.0.1 compile fail Couldn't find module Network.BSD
+        - parsec-numeric ^>= 0.1.0.0
+        - mallard < 0
+        - gdax < 0
+
+    "Callum Rogers @CRogers":
+        - should-not-typecheck ^>= 2.1.0
+
+    "Mihaly Barasz klao@nilcons.com @klao":
+        - lens-datetime < 0
+        - tz ^>= 0.1.3.6
+        - tzdata ^>= 0.2.20230322.0
+
+    "Timothy Klim <stackage@timothyklim.com> @TimothyKlim":
+        - pkcs10 < 0
+
+    "David Luposchainsky <dluposchainsky (λ) googles email service> @quchen":
+        - pgp-wordlist < 0 # 0.1.0.3 # fails to compile (#7017) https://github.com/quchen/pgp-wordlist/pull/4
+        - show-prettyprint < 0
+
+    "Jeremy Shaw <jeremy@n-heptane.com> @stepcut":
+        - boomerang ^>= 1.4.9
+        - happstack-hsp < 0
+        - happstack-jmacro ^>= 7.0.12.5
+        - happstack-server ^>= 7.8.0.2 && <7.9 # https://github.com/commercialhaskell/stackage/issues/7207
+        - happstack-server-tls ^>= 7.2.1.3
+        - hsx-jmacro < 0
+        - ixset < 0
+        - reform < 0
+        - reform-blaze < 0
+        - reform-hamlet < 0
+        - reform-happstack < 0
+        - reform-hsp < 0
+        - userid < 0
+        - web-plugins < 0
+        - web-routes < 0 # 0.27.15 # fails to compile (#7017)
+        - web-routes-boomerang < 0
+        - web-routes-happstack < 0
+        - web-routes-hsp < 0
+        - web-routes-th < 0
+        - web-routes-wai < 0
+        - hsx2hs < 0
+
+    "Pedro Tacla Yamada <tacla.yamada@gmail.com> @yamadapc":
+        - ascii-progress ^>= 0.3.3.0
+        - drawille ^>= 0.1.3.0
+        - file-modules ^>= 0.1.2.4
+        - frontmatter ^>= 0.1.0.2
+        - read-editor ^>= 0.1.0.2
+        - list-prompt < 0 # 0.1.1.0 compile fail https://github.com/yamadapc/list-prompt/issues/3
+        - package-description-remote < 0 # 0.2.0.0 compile fail
+        - projectroot ^>= 0.2.0.1
+        - questioner < 0
+        - language-dockerfile < 0 # 0.3.6.0 compile fail https://github.com/beijaflor-io/haskell-language-dockerfile/issues/11
+
+    "Pascal Hartig <phartig@rdrei.net> @passy":
+        - giphy-api < 0
+        - optparse-text ^>= 0.1.1.0
+
+    "rightfold <rightfold@gmail.com> @rightfold":
+        - open-browser ^>= 0.2.1.0
+
+    "Denis Redozubov <denis.redozubov@gmail.com> @dredozubov":
+        - hreader-lens ^>= 0.1.3.0
+        - schematic < 0
+
+    "Yuji Yamamoto <whosekiteneverfly@gmail.com> @igrep":
+        - yes-precure5-command ^>= 5.5.3
+        - th-strict-compat ^>= 0.1.0.1
+        - main-tester ^>= 0.2.0.1
+        - skews ^>= 0.1.0.3
+        - wss-client ^>= 0.3.0.0
+        - network-messagepack-rpc ^>= 0.1.2.0
+        - network-messagepack-rpc-websocket ^>= 0.1.1.1
+        - unicode-show ^>= 0.1.1.1
+        - deriveJsonNoPrefix ^>= 0.1.0.1
+        - fakefs ^>= 0.3.0.2
+        - fakepull ^>= 0.3.0.2
+
+    "Hans-Christian Esperer <hc@hcesperer.org> @hce":
+        - avwx < 0
+        - saltine ^>= 0.2.1.0
+        - wai-session-postgresql ^>= 0.2.1.3
+
+    "Haisheng Wu <freizl@gmail.com> @freizl":
+        - hoauth2 ^>= 2.10.0
+
+    "Falko Peters <falko.peters@gmail.com> @informatikr":
+        - scrypt ^>= 0.5.0
+
+    "Jakub Waszczuk <waszczuk.kuba@gmail.com> @kawu":
+        - dawg-ord < 0
+
+    "Amit Levy <amit@amitlevy.com> @alevy":
+        - simple ^>= 2.0.0
+        - simple-templates ^>= 2.0.0
+        - simple-session ^>= 2.0.0
+        - postgresql-orm < 0
+
+    "Sergey Astanin <s.astanin@gmail.com> @astanin":
+        # Stackage server uses Ubuntu 20.04 which ships libzip-?.
+        # Haskell packages should match major.minor versions of the C library.
+        - bindings-libzip ^>= 1.0.1
+        - LibZip < 0 # 1.0.1 undefined reference to 'zip_archive_set_tempdir'
+
+    "Anthony Cowley <acowley@gmail.com> @acowley":
+        - vinyl ^>= 0.14.3
+        - Frames ^>= 0.7.4.2
+        - hpp ^>= 0.6.5
+
+    "Takayuki Muranushi <muranushi@gmail.com> @nushio3":
+        - binary-search ^>= 2.0.0
+
+    "Jason Shipman <jasonpshipman@gmail.com> @jship":
+        - context ^>= 0.2.0.3
+        - context-http-client ^>= 0.2.0.2
+        - context-resource ^>= 0.2.0.2
+        - context-wai-middleware ^>= 0.2.0.2
+        - monad-logger-aeson ^>= 0.4.1.2
+        - overhang ^>= 1.0.0
+        - tao ^>= 1.0.0
+        - tao-example ^>= 1.0.0
+
+    "Suhail Shergill <suhailshergill@gmail.com> @suhailshergill":
+        - extensible-effects ^>= 5.0.0.1
+
+    "Justus Adam <dev@justus.science> @JustusAdam":
+        - marvin < 0
+        - marvin-interpolate < 0
+        - mustache ^>= 2.4.2
+        - exit-codes ^>= 1.0.0
+
+    "Cindy Wang <cindylinz@gmail.com> @CindyLinz":
+        - NoTrace < 0
+        - linked-list-with-iterator < 0
+
+    "Jean-Philippe Bernardy <jean-philippe.bernardy@tweag.io> @jyp":
+        - polynomials-bernstein ^>= 1.1.2
+        - typography-geometry ^>= 1.0.1.0
+
+    "John MacFarlane <jgm@berkeley.edu> @jgm":
+        - hsb2hs < 0
+        - cmark ^>= 0.6.1
+        - texmath ^>= 0.12.8.6
+        - highlighting-kate < 0 # 0.6.4 compile fail ghc-9.6
+        - skylighting ^>= 0.14.1
+        - skylighting-core ^>= 0.14.1
+        - pandoc-types ^>= 1.23.1
+        - zip-archive ^>= 0.4.3
+        - doclayout ^>= 0.4.0.1
+        - doctemplates ^>= 0.11
+        - emojis ^>= 0.1.3
+        - pandoc ^>= 3.1.11
+        - pandoc-cli ^>= 3.1.11
+        - pandoc-server ^>= 0.1.0.4
+        - citeproc ^>= 0.8.1
+        - commonmark ^>= 0.2.4.1
+        - commonmark-extensions ^>= 0.2.5.1
+        - commonmark-pandoc ^>= 0.2.2
+        - unicode-collation ^>= 0.1.3.5
+        - ipynb ^>= 0.2
+        - skylighting-format-ansi ^>= 0.1
+        - skylighting-format-blaze-html ^>= 0.1.1.1
+        - skylighting-format-context ^>= 0.1.0.2
+        - skylighting-format-latex ^>= 0.1
+        - typst ^>= 0.5
+        - typst-symbols ^>= 0.1.5
+
+    "Karun Ramakrishnan <karun012@gmail.com> @karun012":
+        - doctest-discover ^>= 0.2.0.0
+
+    "Elie Genard <elaye.github.io@gmail.com> @elaye":
+        - turtle-options < 0
+
+    "Ozgun Ataman ozgun.ataman@soostone.com @ozataman":
+        - string-conv ^>= 0.2.0
+        - rng-utils ^>= 0.3.1
+        - ua-parser ^>= 0.7.7.0
+        - hs-GeoIP ^>= 0.3
+        - retry ^>= 0.9.3.1
+        - katip ^>= 0.8.8.0
+        - katip-elasticsearch < 0 # 0.7.0.0 compile fail https://github.com/commercialhaskell/stackage/issues/6341
+
+    "Sid Kapur sidharthkapur1@gmail.com @sid-kap":
+        - tuple ^>= 0.3.0.2
+        - OneTuple ^>= 0.4.1.1
+
+    "Aaron Levin <vilevin@gmail.com> @aaronmblevin":
+        - free-vl ^>= 0.1.4
+
+    "Kazuo Koga <obiwanko@me.com> @kkazuo":
+        - xlsx-tabular < 0 # 0.2.2.1 https://github.com/kkazuo/xlsx-tabular/issues/9
+
+    "Mikhail Glushenkov <mikhail.glushenkov@gmail.com> @23Skidoo":
+        # - Cabal # take the one that ships with GHC
+        - cabal-install ^>= 3.10.2.1
+        - pointful < 0
+
+    "Lennart Kolmodin <kolmodin@gmail.com> @kolmodin":
+        - binary-bits < 0
+
+    "Alex McLean <alex@slab.org> @yaxu":
+        - tidal ^>= 1.9.4
+        - tidal-link ^>= 1.0.2
+        - hosc ^>= 0.20
+
+    "Kei Hibino <ex8k.hibino@gmail.com> @khibino":
+        - th-data-compat ^>= 0.1.3.0
+        - th-reify-compat ^>= 0.0.1.5
+        - th-bang-compat ^>= 0.0.1.0
+        - th-constraint-compat ^>= 0.0.1.0
+        - product-isomorphic ^>= 0.0.3.4
+        - persistable-record ^>= 0.6.0.6
+        - relational-query ^>= 0.12.3.1
+        - relational-query-HDBC ^>= 0.7.2.1
+        - persistable-types-HDBC-pg ^>= 0.0.3.5
+        - relational-record ^>= 0.2.2.0
+        - text-ldap ^>= 0.1.1.14
+        - debian-build ^>= 0.10.2.1
+        - aeson-generic-compat ^>= 0.0.2.0
+        - json-rpc-generic < 0
+        - protocol-radius ^>= 0.0.1.1
+        - protocol-radius-test ^>= 0.1.0.1
+
+    "wren romano <wren@community.haskell.org> @wrengr":
+        - bytestring-lexing ^>= 0.5.0.11
+        - bytestring-trie ^>= 0.2.7.2
+        - data-or ^>= 1.0.0.7
+        - exact-combinatorics ^>= 0.2.0.11
+        - logfloat ^>= 0.14.0
+        - pointless-fun ^>= 1.1.0.8
+        - prelude-safeenum ^>= 0.1.1.3
+        - stm-chans ^>= 3.0.0.9
+        - unification-fd < 0
+        - unix-bytestring ^>= 0.4.0
+
+    "Fraser Tweedale <frase@frase.id.au> @frasertweedale":
+        - concise ^>= 0.1.0.1
+        - dyre ^>= 0.9.2
+        - jose ^>= 0.11
+
+    "Yoshikuni Jujo <yoshikuni.jujo@gmail.com> @YoshikuniJujo":
+        - zot ^>= 0.0.3
+        - yjtools ^>= 0.9.18
+        - io-machine ^>= 0.2.0.0
+        - yjsvg ^>= 0.2.0.1
+        - x11-xim ^>= 0.0.9.0
+        - X11-xft ^>= 0.3.4
+        - Imlib ^>= 0.1.2
+        - xturtle < 0
+        - gluturtle < 0
+        - papillon < 0
+        - zasni-gerna < 0
+        - exception-hierarchy ^>= 0.1.0.10
+        - simplest-sqlite < 0
+        - warp-tls-uid < 0 # 0.2.0.6 https://github.com/YoshikuniJujo/warp-tls-uid/issues/1
+        - nowdoc ^>= 0.1.1.0
+        - typecheck-plugin-nat-simple ^>= 0.1.0.9
+        - ranged-list ^>= 0.1.2.1
+        - c-enum ^>= 0.1.1.3
+        - c-struct ^>= 0.1.3.0
+        - union-angle ^>= 0.1.0.1
+        - moffy ^>= 0.1.1.0
+        - freer-par-monad ^>= 0.1.0.0
+        - type-set ^>= 0.1.0.0
+        - type-flip ^>= 0.1.0.0
+        - extra-data-yj ^>= 0.1.0.0
+        - moffy-samples-events ^>= 0.2.2.4
+        - moffy-samples ^>= 0.1.0.2
+        - moffy-samples-gtk4-run < 0 # 0.1.0.0 requires newer glib https://github.com/YoshikuniJujo/moffy-samples-gtk4-run/issues/1
+        - moffy-samples-gtk4 < 0
+        - simple-cairo ^>= 0.1.0.6
+        - simple-pango ^>= 0.1.0.1
+        - cairo-image ^>= 0.1.0.2
+        - union-color ^>= 0.1.2.1
+        - glib-stopgap ^>= 0.1.0.0
+
+    "Jan Gerlinger <git@jangerlinger.de> @JanGe":
+        - irc-dcc < 0
+
+    "Alexey Raga <alexey.raga@gmail.com> @AlexeyRaga":
+        - hw-kafka-client ^>= 5.3.0
+
+    "John Ky newhoggy@gmail.com @newhoggy":
+        - aeson-lens < 0
+        - antiope-core < 0 # 7.5.3 fails to compile we amazonka 2.0
+        - antiope-dynamodb < 0
+        - antiope-messages < 0 # 7.5.3 https://github.com/arbor/antiope/issues/112
+        - antiope-s3 < 0
+        - antiope-sns < 0 # 7.5.3 fails to compile we amazonka 2.0
+        - antiope-sqs < 0 # 7.5.3 fails to compile we amazonka 2.0
+        - arbor-lru-cache ^>= 0.1.1.1
+        - arbor-postgres < 0
+        - asif < 0 # 6.0.4 compile fail - https://github.com/arbor/asif/issues/48
+        - avro ^>= 0.6.1.2
+        - bits-extra < 0
+        - hw-balancedparens < 0
+        - hw-bits ^>= 0.7.2.2
+        - hw-conduit ^>= 0.2.1.1
+        - hw-conduit-merges ^>= 0.2.1.0
+        - hw-diagnostics ^>= 0.0.1.0
+        - hw-dsv < 0 # 0.4.1.1 compile fail
+        - hw-eliasfano < 0
+        - hw-excess < 0
+        - hw-fingertree ^>= 0.1.2.1
+        - hw-fingertree-strict ^>= 0.1.2.1
+        - hw-hedgehog < 0
+        - hw-hspec-hedgehog ^>= 0.1.1.1
+        - hw-int ^>= 0.0.2.0
+        - hw-ip < 0
+        - hw-json < 0
+        - hw-json-simple-cursor < 0
+        - hw-json-standard-cursor < 0
+        - hw-mquery < 0
+        - hw-packed-vector < 0
+        - hw-parser ^>= 0.1.1.0
+        - hw-prim ^>= 0.6.3.2
+        - hw-rankselect < 0
+        - hw-rankselect-base < 0
+        - hw-simd < 0
+        - hw-streams < 0 # 0.0.1.0 compile fail https://github.com/haskell-works/hw-streams/issues/81
+        - hw-succinct < 0
+        - hw-xml < 0
+        - oops ^>= 0.2.0.1
+        - tasty-discover ^>= 5.0.0
+
+    "George Wilson <george@wils.online> @gwils":
+        - hedgehog-fn ^>= 1.0
+        - sv < 0
+        - sv-cassava < 0
+        - sv-core < 0
+        - tasty-hedgehog ^>= 1.4.0.2
+
+    "Ismail Mustafa <ismailmustafa@rocketmail.com> @ismailmustafa":
+        - handwriting ^>= 0.1.0.3
+
+    "Stephen Diehl <stephen.m.diehl@gmail.com> @sdiehl":
+        - llvm-hs-pretty < 0
+        - protolude ^>= 0.3.3
+        - repline ^>= 0.4.2.0
+        - picosat < 0
+        - aos-signature ^>= 0.1.1
+        - bulletproofs < 0
+        - pedersen-commitment ^>= 0.2.0
+        - merkle-tree ^>= 0.1.1
+        - oblivious-transfer ^>= 0.1.0
+        - pairing < 0
+        - libraft < 0
+        - galois-field < 0
+
+    "Daishi Nakajima <nakaji.dayo@gmail.com> @nakaji-dayo":
+        - api-field-json-th ^>= 0.1.0.2
+
+    "Patrick Thomson <patrick@helium.com> @helium":
+        - postgresql-transactional < 0
+
+    "Tom Murphy <amindfv@gmail.com>":
+        - gingersnap < 0 # 0.3.1.0 compile fail aeson 2
+        - microspec ^>= 0.2.1.3
+        - midair ^>= 0.2.0.1
+        - nano-erl ^>= 0.1.0.1
+        - rando ^>= 0.0.0.4
+        - vivid < 0 # 0.5.2.0 # fails to compile (#7017)
+        - vivid-osc ^>= 0.5.0.0
+        - vivid-supercollider ^>= 0.4.1.2
+
+    "Toshio Ito <debug.ito@gmail.com> @debug-ito":
+        - fold-debounce ^>= 0.2.0.11
+        - fold-debounce-conduit < 0
+        - stopwatch < 0
+        - wikicfp-scraper < 0
+        - wild-bind < 0
+        - wild-bind-x11 < 0
+        - greskell < 0
+        - greskell-core < 0
+        - greskell-websocket < 0
+        - hspec-need-env < 0
+
+    "Cies Breijs <cies@kde.nl> @cies":
+        - htoml < 0
+
+    "Martijn Rijkeboer <mrr@sru-systems.com> @mrijkeboer":
+        - protobuf-simple ^>= 0.1.1.1
+
+    "David Reaver <johndreaver@gmail.com> @jdreaver":
+        - eventful-core < 0
+        - eventful-dynamodb < 0
+        - eventful-memory < 0
+        - eventful-postgresql < 0
+        - eventful-sql-common < 0
+        - eventful-sqlite < 0
+        - eventful-test-helpers < 0
+        - stratosphere ^>= 0.60.0
+        - sum-type-boilerplate < 0
+
+    "Iñaki García Etxebarria <garetxe@gmail.com> @garetxe":
+        - haskell-gi ^>= 0.26.7
+        - haskell-gi-base ^>= 0.26.4
+        - gi-atk ^>= 2.0.27
+        - gi-cairo ^>= 1.0.29
+        - gi-dbusmenu ^>= 0.4.13
+        - gi-dbusmenugtk3 ^>= 0.4.14
+        - gi-gdk ^>= 3.0.28 && >=3 && <4 # https://github.com/commercialhaskell/stackage/issues/6317
+        - gi-gdkpixbuf ^>= 2.0.31
+        - gi-gdkx11 ^>= 3.0.15 && >=3 && <4 # https://github.com/commercialhaskell/stackage/issues/6317
+        - gi-gio ^>= 2.0.32
+        - gi-glib ^>= 2.0.29
+        - gi-gobject ^>= 2.0.30
+        - gi-graphene ^>= 1.0.7
+        - gi-gsk < 0
+        - gi-gtk ^>= 3.0.41 && >=3 && <4 # https://github.com/commercialhaskell/stackage/issues/6317
+        - gi-gtk-hs ^>= 0.3.16
+        - gi-gmodule ^>= 2.0.5
+        - gi-pango ^>= 1.0.29
+        - gi-xlib ^>= 2.0.13
+        - gi-harfbuzz ^>= 0.0.9
+        - gi-gtksource ^>= 3.0.28 && <5.0.0 # https://github.com/commercialhaskell/stackage/issues/7013
+        - gi-javascriptcore ^>= 4.0.27 && <6.0.3 # https://github.com/commercialhaskell/stackage/issues/6929
+        - gi-vte ^>= 2.91.31
+        - gi-webkit2 ^>= 4.0.30
+        - gi-freetype2 ^>= 2.0.4
+        - gi-soup ^>= 2.4.28 && <3.0.2 # https://github.com/commercialhaskell/stackage/issues/6929
+
+    "Brandon Simmons <brandon.m.simmons@gmail.com> @jberryman":
+        - directory-tree ^>= 0.12.1
+
+    "Drew Hess <src@drewhess.com> @dhess":
+        - hpio < 0
+
+    "Richard Eisenberg <eir@cis.upenn.edu> @goldfirere":
+        - th-desugar ^>= 1.15
+        - singletons ^>= 3.0.2
+        - HUnit-approx ^>= 1.1.1.1
+        - units-parser ^>= 0.1.1.5
+
+    "Doug McClean <douglas.mcclean@gmail.com> @dmcclean":
+        - dimensional ^>= 1.5
+        - exact-pi ^>= 0.5.0.2
+        - numtype-dk ^>= 0.5.0.3
+
+    "Bjorn Buckwalter <bjorn@buckwalter.se> @bjornbm":
+        - leapseconds-announced ^>= 2017.1.0.1
+
+    "Pavel Ryzhov <paul@paulrz.cz> @paulrzcz":
+        - hquantlib < 0
+        - hquantlib-time < 0
+        - HSvm ^>= 0.1.1.3.25
+
+    "Henri Verroken <henriverroken@gmail.com> @hverr":
+        - bordacount ^>= 0.1.0.0
+        - cache ^>= 0.1.3.0
+        - haskey < 0
+        - haskey-btree < 0
+        - haskey-mtl < 0
+        - intset-imperative ^>= 0.1.0.0
+        - lxd-client < 0
+        - lxd-client-config < 0
+        - xxhash-ffi ^>= 0.2.0.0
+        - zeromq4-patterns ^>= 0.3.1.0
+
+    "Cliff Harvey <cs.hbar+hs@gmail.com> @BlackBrane":
+        - ansigraph < 0
+        - microsoft-translator < 0
+
+    "Tebello Thejane <zyxoas+stackage@gmail.com> @tebello-thejane":
+        - bitx-bitcoin < 0 # 0.12.0.0 compile fail
+
+    "Andrew Lelechenko <andrew.lelechenko@gmail.com> @Bodigrim":
+        - exp-pairs ^>= 0.2.1.0
+        - fast-digits ^>= 0.3.2.0
+        - chimera ^>= 0.3.4.0
+        - quadratic-irrational ^>= 0.1.1
+        - primitive-addr ^>= 0.1.0.2
+        - quickcheck-classes ^>= 0.6.5.0
+        - quickcheck-classes-base ^>= 0.6.2.0
+        - arithmoi ^>= 0.13.0.0
+        - bitvec ^>= 1.1.5.0
+        - poly ^>= 0.5.1.0
+        - extended-reals ^>= 0.2.4.0
+        - ChasingBottoms ^>= 1.3.1.12
+        - data-interval ^>= 2.1.1
+        - vector-rotcev ^>= 0.1.0.2
+        - mod ^>= 0.2.0.1
+        - tasty-rerun ^>= 1.1.19
+        - integer-roots ^>= 1.0.2.0
+        - smallcheck ^>= 1.2.1.1
+        - quote-quot ^>= 0.2.1.0
+        - tasty-bench ^>= 0.3.5
+        - tasty-inspection-testing ^>= 0.2
+        - text-rope ^>= 0.2
+        - data-array-byte ^>= 0.1.0.1
+        - text-builder-linear ^>= 0.1.2
+        - hie-bios ^>= 0.13.1
+        - infinite-list ^>= 0.1
+        - regression-simple ^>= 0.2.1
+        - tasty-bench-fit ^>= 0.1
+        - alex-tools ^>= 0.6.1
+        - language-lua ^>= 0.11.0.1
+        - snap-server ^>= 1.1.2.1
+
+    "Ashley Yakeley <ashley@semantic.org> @AshleyYakeley":
+        - countable ^>= 1.2
+        - witness ^>= 0.6.2
+        - open-witness ^>= 0.6
+        - type-rig ^>= 0.1
+        - monadology ^>= 0.3
+        - primitive-serial ^>= 0.1
+
+    "Victor Denisov <denisovenator@gmail.com> @VictorDenisov":
+        - mongoDB ^>= 2.7.1.2
+        - bson ^>= 0.4.0.1
+
+    "Alexis King <lexi.lambda@gmail.com> @lexi-lambda":
+        - freer-simple < 0
+        - monad-mock < 0
+        - test-fixture < 0
+        - text-conversions ^>= 0.3.1.1
+        - th-to-exp < 0
+        - type-assertions < 0
+
+    "Patrick Chilton <chpatrick@gmail.com> @chpatrick":
+        - webrtc-vad ^>= 0.1.0.3
+        - clang-pure < 0 # 0.2.0.6 missing system libraries #3810/closed
+        - codec < 0
+
+    "Michal Konecny <mikkonecny@gmail.com> @michalkonecny":
+        - hmpfr ^>= 0.4.5
+        - collect-errors ^>= 0.1.5.0
+        - mixed-types-num ^>= 0.5.12
+        - cdar-mBound ^>= 0.1.0.4
+        - aern2-mp ^>= 0.2.15.1
+        - aern2-real ^>= 0.2.15
+
+    "Bartosz Nitka <niteria@gmail.com> @niteria":
+        - oeis < 0
+
+    "Gergely Patai <patai.gergely@gmail.com> @cobbpg":
+        - elerea ^>= 2.9.0
+
+    "Christopher Wells <cwellsny@nycap.rr.com> @ExcalburZero":
+        - pixelated-avatar-generator < 0
+
+    "Dominic Orchard <dom.orchard@gmail.com> @dorchard":
+        - array-memoize ^>= 0.6.0
+        - codo-notation < 0 # 0.5.2 compile fail MonadFail
+        - fortran-src < 0
+
+    "Cheng Shao <astrohavoc@gmail.com> @TerrorJack":
+        - binaryen ^>= 0.0.6.0
+        - cabal-toolkit < 0
+        - direct-rocksdb < 0
+
+    "Anton Gushcha <ncrashed@gmail.com> @ncrashed":
+        - aeson-injector < 0
+        - JuicyPixels-blp < 0
+
+    "Al Zohali <zohl@fmap.me> @zohl":
+        - servant-auth-cookie < 0
+        - dictionaries < 0
+        - cereal-time < 0
+
+    "Joachim Fasting <joachifm@fastmail.fm> @joachifm":
+        - libmpd < 0
+
+    "Moritz Kiefer <moritz.kiefer@purelyfunctional.org> @cocreature":
+        - lrucaching < 0
+        - llvm-hs < 0
+        - llvm-hs-pure < 0
+
+    "Thierry Bourrillon <thierry.bourrillon@fpinsight.com> @tbourrillon":
+        - heatshrink ^>= 0.1.0.0
+        - hocilib < 0
+
+    "Daniel Mendler <mail@daniel-mendler.de> @minad":
+        - quickcheck-special ^>= 0.1.0.6
+        - writer-cps-mtl < 0
+        - writer-cps-transformers ^>= 0.5.6.1
+        - writer-cps-morph < 0 # 0.1.0.2 compile fail https://github.com/louispan/writer-cps-morph/issues/2
+        - writer-cps-lens < 0
+        - writer-cps-full < 0
+        - writer-cps-exceptions < 0
+        - wl-pprint-annotated ^>= 0.1.0.1
+        - wl-pprint-console < 0
+        - console-style < 0
+        - unlit ^>= 0.4.0.0
+        - intro < 0
+        - tasty-stats < 0
+        - colorful-monoids ^>= 0.2.1.3
+        - ihs ^>= 0.1.0.3
+        - paripari < 0
+        - persist < 0
+
+    "Taras Serduke <taras.serduke@gmail.com> @tserduke":
+        - do-list ^>= 1.0.1
+
+    "Travis Whitaker <pi.boy.travis@gmail.com>":
+        - cpuinfo ^>= 0.1.0.2
+        - lmdb ^>= 0.2.5
+        - rdf < 0
+        - data-compat < 0
+        - deepseq-instances < 0
+
+    "Michael Swan <mswan@fastmail.com> @michael-swan":
+        - pcf-font ^>= 0.2.2.1
+        - pcf-font-embed < 0 # 0.1.2.0 compile fail
+
+    "Iago Abal <iagoabal+stack@gmail.com>":
+        - bv ^>= 0.5
+
+    "Juan Pedro Villa Isaza @jpvillaisaza":
+        - licensor < 0
+
+    "Florian Hofmann fho@f12n.de @fhaust":
+        - vector-split ^>= 1.0.0.3
+        - vector-mmap ^>= 0.0.3
+
+    "Ondrej Palkovsky <palkovsky.ondrej@gmail.com> @ondrap":
+        - json-stream ^>= 0.4.5.3
+
+    "Philipp Balzarek <p.balzarek@googlemail.com>":
+        - xml-picklers ^>= 0.3.6
+
+    "Lennart Spitzner <hexagoxel@hexagoxel.de> @lspitzner":
+        - multistate ^>= 0.8.0.4
+        - pqueue ^>= 1.5.0.0
+        - butcher < 0
+        - czipwith < 0
+        - data-tree-print < 0
+        - brittany < 0
+
+    "Ryan Mulligan <ryan@ryantm.com> @ryantm":
+        - HDBC-mysql < 0
+
+    "Tony Morris <haskell@tmorris.net> @tonymorris":
+        - validation ^>= 1.1.3
+
+    "Tony Day <tonyday567@gmail.com> @tonyday567":
+        - chart-svg ^>= 0.5.2.0
+        - markup-parse ^>= 0.1.1
+        - numhask ^>= 0.11.1.0
+        - numhask-array ^>= 0.11.0.1
+        - numhask-space ^>= 0.11.1.0
+        - perf ^>= 0.12.0.0
+
+    "Iphigenia Df <iphydf@gmail.com> @iphydf":
+        - data-msgpack ^>= 0.0.13
+        - network-msgpack-rpc < 0
+
+    "Dino Morelli <dino@ui3.info> @dino-":
+        - epub-metadata ^>= 5.2
+        - hsinstall ^>= 2.8
+        - tce-conf ^>= 1.3
+
+    "Jonathan Fischoff <jonathangfischoff@gmail.com> @jfischoff":
+        - clock-extras < 0
+        - postgres-options ^>= 0.2.1.0
+        - tmp-postgres < 0 # 1.34.1.0 compile failure https://github.com/commercialhaskell/stackage/issues/7140
+        - pg-transact ^>= 0.3.2.0
+        - port-utils ^>= 0.2.1.0
+        - postgresql-libpq-notify ^>= 0.2.0.0
+        - hasql-queue < 0
+
+    "Jonathan Knowles <stackage@jonathanknowles.net> @jonathanknowles":
+        - bech32 ^>= 1.1.4
+        - bech32-th ^>= 1.1.1
+        - cardano-coin-selection ^>= 1.0.1
+        - quickcheck-groups ^>= 0.0.1.0
+        - quickcheck-monoid-subclasses ^>= 0.3.0.0
+        - quiet ^>= 0.2
+        - roc-id ^>= 0.2.0.0
+
+    "Mahdi Dibaiee <mdibaiee@aol.com> @mdibaiee":
+        - picedit < 0
+        - mathexpr ^>= 0.3.1.0
+        - termcolor < 0
+
+    "XT <e@xtendo.org> @xtendo-org":
+        - rawfilepath ^>= 1.1.0
+
+    "Konstantin Zudov <co@zudov.me> @zudov":
+        - html-email-validate ^>= 0.2.0.0
+
+    "Carl Baatz <carl.baatz@gmail.com> @cbaatz":
+        - atom-basic ^>= 0.2.5
+
+    "Reuben D'Netto <rdnetto@gmail.com>":
+        - glob-posix ^>= 0.2.0.1
+
+    "Kadzuya Okamoto <arow.okamoto@gmail.com> @arowM":
+        - type-level-kv-list ^>= 2.0.2.0
+        - heterocephalus ^>= 1.0.5.7
+        - bookkeeping < 0
+        - ochintin-daicho < 0
+        - transaction ^>= 0.1.1.4
+        - tonaparser < 0
+        - tonalude < 0
+        - tonatona < 0
+        - tonatona-logger < 0
+        - tonatona-servant < 0
+        - tonatona-persistent-sqlite < 0
+        - tonatona-persistent-postgresql < 0
+
+    "Marcin Tolysz <tolysz@gmail.com> @tolysz":
+        - rawstring-qm ^>= 0.2.3.0
+
+    "Daniel YU <leptonyu@gmail.com>":
+        - salak < 0
+        - salak-yaml < 0
+        - salak-toml < 0
+        - tensors ^>= 0.1.5
+        - menshen < 0
+        - crc32c ^>= 0.1.0
+        - boots < 0
+
+    "Tom Nielsen <tanielsen@gmail.com> @glutamate":
+        - plotlyhs ^>= 0.2.3
+        - inliterate < 0
+
+    "Hyunje Jun <me@noraesae.net> @noraesae":
+        - line ^>= 4.0.1
+
+    "Hannes Saffrich <m0rphism@zankapfel.org> @m0rphism":
+        - printcess < 0
+
+    "Alexey Kuleshevich <lehins@yandex.ru> @lehins":
+        - hip < 0
+        - massiv ^>= 1.0.4.0
+        - massiv-io ^>= 1.0.0.1
+        - massiv-test ^>= 1.0.0.0
+        - massiv-serialise ^>= 1.0.0.2
+        - massiv-persist < 0
+        - scheduler ^>= 2.0.0.1
+        - Color ^>= 0.3.3
+        - safe-decimal ^>= 0.2.1.0
+        - flush-queue ^>= 1.0.0
+        - pvar ^>= 1.0.0.0
+        - conduit-aeson ^>= 0.1.0.1
+        - vector-stream ^>= 0.1.0.0
+        - FailT ^>= 0.1.2.0
+
+    "Hans-Peter Deifel <hpd@hpdeifel.de> @hpdeifel":
+        - hledger-iadd ^>= 1.3.19
+
+    "Roy Levien <royl@aldaron.com> @orome":
+        - crypto-enigma < 0 # 0.1.1.6 compile fail https://github.com/orome/crypto-enigma-hs/issues/36
+
+    "Boldizsár Németh <nboldi@elte.hu> @nboldi":
+        - instance-control < 0
+        - references < 0 # 0.3.3.1 compile fail
+        - classyplate < 0
+        - haskell-tools-ast < 0
+        - haskell-tools-backend-ghc < 0
+        - haskell-tools-prettyprint < 0
+        - haskell-tools-refactor < 0
+        - haskell-tools-rewrite < 0
+        - haskell-tools-demo < 0
+        - haskell-tools-cli < 0
+        - haskell-tools-daemon < 0
+        - haskell-tools-debug < 0
+
+    "David Fisher <ddf1991@gmail.com> @ddfisher":
+        - socket-activation < 0
+
+    "aiya000 <aiya000.develop@gmail.com> @aiya000":
+        - character-cases ^>= 0.1.0.6
+        - throwable-exceptions < 0
+
+    "Mitsutoshi Aoe <maoe@foldr.in> @maoe":
+        - influxdb ^>= 1.9.3
+        - sensu-run < 0
+        - viewprof < 0
+
+    "Dylan Simon <dylan-stack@dylex.net> @dylex":
+        - postgresql-typed ^>= 0.6.2.5
+        - invertible ^>= 0.2.0.8
+        - ztail < 0
+        - zip-stream ^>= 0.2.2.0
+
+    "Louis Pan <louis@pan.me> @louispan":
+        - alternators ^>= 1.0.0.0
+        - arrow-extras ^>= 0.1.0.1
+        - data-diverse ^>= 4.7.1.0
+        - data-diverse-lens < 0 # 4.3.0.0 compile fail (lens)
+        - ghcjs-base-stub < 0
+        - glaze < 0
+        - glazier < 0 # 1.0.0.0 compile fail (lens)
+        - glazier-react < 0
+        - glazier-react-widget < 0
+        - javascript-extras < 0
+        - lens-misc ^>= 0.0.2.0
+        - l10n < 0
+        - pipes-category < 0
+        - pipes-fluid ^>= 0.6.0.1
+        - pipes-misc < 0
+        - stm-extras ^>= 0.1.0.3
+
+    "Siniša Biđin <sinisa@bidin.eu> @sbidin": []
+
+    "Aditya Manthramurthy <aditya.mmy@gmail.com> @donatello":
+        - minio-hs < 0
+        - webby < 0
+
+    "ncaq <ncaq@ncaq.net> @ncaq":
+        - debug-trace-var ^>= 0.2.0
+        - haskell-import-graph < 0
+        - string-transform ^>= 1.1.1
+        - uniq-deep ^>= 1.2.1
+        - yesod-form-bootstrap4 ^>= 3.0.1.1
+        - yesod-recaptcha2 ^>= 1.0.2.1
+
+    "Andrei Barbu <andrei@0xab.com> @abarbu":
+        - nondeterminism ^>= 1.5
+        - csp ^>= 1.4.0
+        - matplotlib ^>= 0.7.7
+
+    "mackeyrms <librarymaintainer@mackeycorp.com> @mackeyrms":
+        - tsv2csv ^>= 0.1.0.2
+
+    "Thomas Sutton <me@thomas-sutton.id.au> @thsutton":
+        - aeson-diff ^>= 1.1.0.13
+        - edit-distance-vector ^>= 1.0.0.4
+
+    "Kyle Van Berendonck <kvanberendonck+stackage@gmail.com> @donkeybonks":
+        - rot13 ^>= 0.2.0.1
+        - dvorak ^>= 0.1.0.0
+
+    "Cuedo Business Solutions <foss@cuedo.com.au> @cuedo":
+        - github-webhooks ^>= 0.17.0
+
+    "Pavel Yakovlev <pavel@yakovlev.me> @zmactep":
+        - hasbolt < 0
+        - uniprot-kb < 0
+        - mmtf < 0 # 0.1.3.1 compile fail MonadFail
+
+    "Christopher A. Gorski <cgorski@cgorski.org> @cgorski":
+        - general-games ^>= 1.1.1
+
+    "Cristian Adrián Ontivero <cristianontivero@gmail.com> @contivero":
+        - hasmin < 0
+        - hopfli ^>= 0.2.2.1
+
+    "Peter Trško <peter.trsko@gmail.com> @trskop":
+        - between ^>= 0.11.0.0
+        - connection-pool < 0 # 0.2.2 compile fail https://github.com/trskop/connection-pool/issues/2
+        - verbosity ^>= 0.4.0.0
+
+    "Devon Hollowood <devonhollowood@gmail.com> @devonhollowood":
+        - search-algorithms ^>= 0.3.2
+
+    "Chris Dornan <chris@chrisdornan.com> @cdornan":
+        - sort ^>= 1.0.0.0
+        - regex ^>= 1.1.0.2
+        - regex-pcre-text < 0
+        - regex-with-pcre ^>= 1.1.0.2
+        - possibly ^>= 1.0.0.0
+        - enum-text ^>= 0.5.3.0
+        - rg ^>= 1.4.0.0
+        - columnar ^>= 1.0.0.0
+        - no-value ^>= 1.0.0.0
+        - optparse-enum ^>= 1.0.0.0
+        - fmt ^>= 0.6.3.0
+
+    "Elliot Cameron <eacameron@gmail.com> @3noch":
+        - ziptastic-client < 0
+        - ziptastic-core < 0
+
+    "Hardy Jones <jones3.hardy@gmail.com> @joneshf":
+        - katip-rollbar < 0
+        - rollbar-hs < 0
+        - servant-ruby < 0
+        - wai-middleware-rollbar < 0
+
+    "Andrey Mokhov <andrey.mokhov@gmail.com> @snowleopard":
+        - algebraic-graphs ^>= 0.7
+
+    "Albert Krewinkel <albert+stackage@zeitkraut.de> @tarleb":
+        - hslua ^>= 2.3.0
+        - hslua-aeson ^>= 2.3.0.1
+        - hslua-classes ^>= 2.3.0
+        - hslua-cli ^>= 1.4.1
+        - hslua-core ^>= 2.3.1
+        - hslua-list ^>= 1.1.1
+        - hslua-marshalling ^>= 2.3.0
+        - hslua-module-doclayout ^>= 1.1.0
+        - hslua-module-path ^>= 1.1.0
+        - hslua-module-system ^>= 1.1.0.1
+        - hslua-module-text ^>= 1.1.0.1
+        - hslua-module-version ^>= 1.1.0
+        - hslua-module-zip ^>= 1.1.0
+        - hslua-objectorientation ^>= 2.3.0
+        - hslua-packaging ^>= 2.3.0
+        - hslua-repl ^>= 0.1.1
+        - hslua-typing ^>= 0.1.0
+        - jira-wiki-markup ^>= 1.5.1
+        - lpeg ^>= 1.0.4
+        - lua ^>= 2.3.1
+        - lua-arbitrary ^>= 1.0.1.1
+        - pandoc-lua-engine ^>= 0.2.1.2
+        - pandoc-lua-marshal ^>= 0.2.2
+        - tasty-hslua ^>= 1.1.0
+        - tasty-lua ^>= 1.1.0
+        - gridtables ^>= 0.1.0.0
+
+    "Judah Jacobson <judah.jacobson@gmail.com> @judah":
+        - proto-lens-protobuf-types < 0
+        - proto-lens-protoc < 0
+        - proto-lens-runtime ^>= 0.7.0.4
+        - proto-lens-setup < 0
+        - proto-lens ^>= 0.7.1.3
+        - proto-lens-arbitrary < 0
+        - proto-lens-optparse < 0
+        - tensorflow-test ^>= 0.1.0.0
+        - pier-core < 0
+        - pier < 0
+        - ghc-source-gen < 0 # tests disabled due to QuickCheck < 2.14
+
+    "Christof Schramm <christof.schramm@campus.lmu.de>":
+        - mnist-idx ^>= 0.1.3.2
+
+    "Naushadh <naushadh@protonmail.com> @naushadh":
+    - persistent-mysql-haskell
+
+    "Moritz Schulte <mtesseract@silverratio.net> @mtesseract":
+        - async-refresh ^>= 0.3.0.0
+        - async-refresh-tokens ^>= 0.4.0.0
+        - type-level-integers ^>= 0.0.1
+        - partial-order ^>= 0.2.0.0
+        - async-timer < 0
+        - nakadi-client < 0
+        - throttle-io-stream < 0
+        - conduit-throttle < 0
+
+    "Simon Hafner <hafnersimon@gmail.com> @reactormonk":
+        - uri-bytestring-aeson ^>= 0.1.0.8
+        - katip-scalyr-scribe < 0
+
+    "Sebastian Witte <woozletoff@gmail.com> @saep":
+        - nvim-hs ^>= 2.3.2.3
+        - nvim-hs-contrib ^>= 2.0.0.2
+        - nvim-hs-ghcid ^>= 2.0.1.0
+
+    "Sam Protas <sam.protas@gmail.com> @SamProtas":
+        - triplesec < 0
+        - composable-associations ^>= 0.1.0.0
+        - composable-associations-aeson < 0
+        - JuicyPixels-blurhash < 0
+
+    "Anton Ekblad <anton@ekblad.cc> @valderman":
+        - selda < 0
+        - selda-sqlite < 0
+        - selda-postgresql < 0
+        - selda-json < 0
+
+    "Luis Pedro Coelho <luis@luispedro.org> @luispedro":
+        - safeio ^>= 0.0.6.0
+        - conduit-algorithms < 0
+        - conduit-zstd ^>= 0.0.2.0
+
+    "Alex Biehl <alexbiehl@gmail.com> @alexbiehl":
+        - haddock-library ^>= 1.11.0
+        - http-client-openssl ^>= 0.3.3
+
+    "Steven Vandevelde <icid.asset@gmail.com> @icidasset":
+        - shikensu < 0
+
+    "George Pollard <porges@porg.es> @Porges":
+        - email-validate ^>= 2.3.2.19
+
+    "Alexander Ignatyev <ignatyev.alexander@gmail.com> @aligusnet":
+        - astro ^>= 0.4.3.0
+        - mltool < 0
+        - hmatrix-morpheus ^>= 0.1.1.2
+
+    "Matt Noonan <matt.noonan@gmail.com> @matt-noonan":
+        - justified-containers ^>= 0.3.0.0
+        - roles ^>= 0.2.1.0
+        - lawful ^>= 0.1.0.0
+        - gdp ^>= 0.0.3.0
+
+    "Levent Erkok <erkokl@gmail.com> @LeventErkok":
+        - sbv ^>= 10.2
+        - crackNum ^>= 3.4
+
+    "János Tapolczai <janos.tapolczai@gmail.com> @jtapolczai":
+        - listsafe ^>= 0.1.0.1
+
+    "Serokell <libraries@serokell.io> @serokell":
+        - importify < 0
+        - log-warper < 0
+        - o-clock ^>= 1.4.0
+        - tasty-hunit-compat ^>= 0.2.0.1
+        - universum ^>= 1.8.2
+        - with-utf8 ^>= 1.0.2.4
+        - uncaught-exception ^>= 0.1.0
+        - tztime ^>= 0.1.1.0
+
+    "Holmusk <tech@holmusk.com> @arbus":
+        - elm-street ^>= 0.2.1.1
+
+    "Noel Kwan <noelkwan1998@gmail.com> @kwannoel":
+        - servant-docs-simple < 0
+
+    "Lorenz Moesenlechner <moesenle@gmail.com> @moesenle":
+        - servant-websockets ^>= 2.0.0
+
+    "Daniel Campoverde <alx@sillybytes.net> @alx741":
+        - currencies < 0
+        - alerts < 0
+        - yesod-alerts < 0
+        - graphite ^>= 0.10.0.1
+
+    "José Lorenzo Rodríguez <jose.zap@gmail.com> @lorenzo":
+        - wrecker < 0
+        - language-docker ^>= 12.1.0
+        - docker-build-cacher < 0
+        - mysql-haskell-nem ^>= 0.1.0.0
+        - hadolint < 0
+
+    "Phil Ruffwind <rf@rufflewind.com> @Rufflewind":
+        - blas-hs ^>= 0.1.1.0
+
+    "Eitan Chatav <eitan@gmail.com> @echatav":
+        - free-categories ^>= 0.2.0.2
+        - squeal-postgresql ^>= 0.9.1.3
+
+    "Sam Quinn <lazersmoke@gmail.com> @Lazersmoke":
+        - ghost-buster ^>= 0.1.1.0
+
+    "typeable.io <makeit@typeable.io>":
+        - dom-parser < 0 # 3.1.0 compile fail
+        - xml-isogen < 0 # 0.3.0 compile fail
+
+    "Jeremy Huffman <jeremy@jeremyhuffman.com> @jeremyjh":
+        - higher-leveldb < 0
+        - distributed-process-lifted < 0
+        - distributed-process-monad-control < 0
+
+    "Adam Curtis <kallisti.dev@gmail.com> @kallisti-dev":
+        - cond ^>= 0.5.1
+
+    "Naoto Shimazaki <naoto.shimazaki@gmail.com> @nshimaza":
+        - thread-hierarchy ^>= 0.3.0.2
+        - thread-supervisor ^>= 0.2.0.0
+        - bitset-word8 ^>= 0.1.1.2
+        - webex-teams-api ^>= 0.2.0.1
+        - webex-teams-conduit ^>= 0.2.0.1
+        - webex-teams-pipes < 0
+
+    "Deni Bertovic <deni@denibertovic.com> @denibertovic & James Parker <dev@jamesparker.me> @jprider63":
+        - docker < 0
+
+    "Hexirp <hexirp@gmail.com> @Hexirp":
+        - doctest-driver-gen ^>= 0.3.0.8
+
+    "Václav Haisman <vhaisman@gmail.com> @wilx":
+        - hs-bibutils ^>= 6.10.0.0
+
+    "Christian Kjær Laustsen <ckl@codetalk.io> @tehnix":
+        - ghc-core ^>= 0.5.6
+        - colorize-haskell ^>= 1.0.1
+
+    "Type Classes <hello@typeclasses.com> @argumatronic @chris-martin":
+        - ascii ^>= 1.7.0.1
+        - ascii-case ^>= 1.0.1.3
+        - ascii-caseless ^>= 0.0.0.1
+        - ascii-char ^>= 1.0.1.0
+        - ascii-group ^>= 1.0.0.16
+        - ascii-numbers ^>= 1.2.0.1
+        - ascii-predicates ^>= 1.0.1.3
+        - ascii-superset ^>= 1.3.0.1
+        - ascii-th ^>= 1.2.0.1
+        - attoparsec-run ^>= 0.0.2.0
+        - aws-cloudfront-signed-cookies ^>= 0.2.0.12
+        - d10 < 0 # 1.0.1.3 builds fine with cabal-install, stack issue?
+        - data-forest ^>= 0.1.0.12
+        - hedgehog-optics < 0
+        - hex-text ^>= 0.1.0.9
+        - integer-types ^>= 0.1.4.0
+        - invert ^>= 1.0.0.4
+        - loc ^>= 0.2.0.0
+        - memfd ^>= 1.0.1.3
+        - partial-semigroup ^>= 0.6.0.2
+        - path-text-utf8 < 0
+        - quaalude ^>= 0.0.0.1
+        - stripe-concepts ^>= 1.0.3.3
+        - stripe-signature ^>= 1.0.0.16
+        - stripe-wreq ^>= 1.0.1.16
+        - systemd-socket-activation ^>= 1.1.0.1
+        - unfork ^>= 1.0.0.1
+
+    "Viacheslav Lotsmanov <lotsmanov89@gmail.com> @unclechu":
+        - place-cursor-at ^>= 1.0.1
+        - qm-interpolated-string ^>= 0.3.1.0
+
+    "Douglas Burke <dburke.gw@gmail.com> @DougBurke":
+        - swish ^>= 0.10.7.0
+        - hvega ^>= 0.12.0.7
+        - ihaskell-hvega ^>= 0.5.0.4
+
+    "Adam Flott <adam@adamflott.com> @adamflott":
+        - milena < 0
+
+    "Csongor Kiss <kiss.csongor.kiss@gmail.com> @kcsongor":
+        - generic-lens ^>= 2.2.2.0
+        - generic-optics ^>= 2.2.1.0
+        - generic-lens-core ^>= 2.2.1.0
+
+    "Bogdan Neterebskii <bog2dan1@gmail.com> @ozzzzz":
+        - cast ^>= 0.1.0.2
+        - aeson-picker ^>= 0.1.0.6
+
+    "Warlock <internalmike@gmail.com> @A1-Triard":
+        - errors-ext ^>= 0.4.2
+        - binary-ext < 0
+
+    "Bob Long <robertjflong@gmail.com> @bobjflong":
+        - yesod-csp < 0 # 0.2.5.0 text 1.2.5.0 exports `elem`
+
+    "Alexander Vershilov <alexander.vershilov@gmail.com> @qnikst":
+        - stm-conduit ^>= 4.0.1
+        - co-log-concurrent ^>= 0.5.1.0
+        - HaskellNet ^>= 0.6.1.2
+
+    "Tung Dao <me@tungdao.com> @tungd":
+        - time-locale-vietnamese ^>= 1.0.0.0
+
+    "Tim McGilchrist <timmcgil@gmail.com>  @tmcgilchrist":
+        - riak < 0
+        - riak-protobuf ^>= 0.25.0.0
+        - airship < 0
+        - hedgehog-corpus ^>= 0.2.0
+
+    "Tom Sydney Kerckhove <syd.kerckhove@gmail.com> @NorfairKing":
+        - appendful ^>= 0.1.0.0
+        - appendful-persistent ^>= 0.1.0.1
+        - autodocodec ^>= 0.2.2.0
+        - autodocodec-openapi3 ^>= 0.2.1.1
+        - autodocodec-schema ^>= 0.1.0.3
+        - autodocodec-yaml ^>= 0.2.0.3
+        - cursor ^>= 0.3.2.0
+        - cursor-brick ^>= 0.1.0.1
+        - cursor-fuzzy-time ^>= 0.0.0.0
+        - cursor-gen ^>= 0.4.0.0
+        - fast-myers-diff ^>= 0.0.0
+        - fuzzy-time ^>= 0.2.0.3
+        - genvalidity ^>= 1.1.0.0
+        - genvalidity-aeson ^>= 1.0.0.1
+        - genvalidity-appendful ^>= 0.1.0.0
+        - genvalidity-bytestring ^>= 1.0.0.1
+        - genvalidity-case-insensitive ^>= 0.0.0.1
+        - genvalidity-containers ^>= 1.0.0.1
+        - genvalidity-criterion ^>= 1.1.0.0
+        - genvalidity-hspec ^>= 1.0.0.3
+        - genvalidity-hspec-aeson ^>= 1.0.0.0
+        - genvalidity-hspec-binary ^>= 1.0.0.0
+        - genvalidity-hspec-cereal ^>= 1.0.0.0
+        - genvalidity-hspec-hashable ^>= 1.0.0.1
+        - genvalidity-hspec-optics ^>= 1.0.0.0
+        - genvalidity-hspec-persistent ^>= 1.0.0.0
+        - genvalidity-mergeful ^>= 0.3.0.1
+        - genvalidity-mergeless ^>= 0.3.0.0
+        - genvalidity-network-uri ^>= 0.0.0.0
+        - genvalidity-path ^>= 1.0.0.1
+        - genvalidity-persistent ^>= 1.0.0.2
+        - genvalidity-property ^>= 1.0.0.0
+        - genvalidity-scientific ^>= 1.0.0.0
+        - genvalidity-sydtest ^>= 1.0.0.0
+        - genvalidity-sydtest-aeson ^>= 1.0.0.0
+        - genvalidity-sydtest-hashable ^>= 1.0.0.1
+        - genvalidity-sydtest-lens ^>= 1.0.0.0
+        - genvalidity-sydtest-persistent ^>= 1.0.0.0
+        - genvalidity-text ^>= 1.0.0.1
+        - genvalidity-time ^>= 1.0.0.1
+        - genvalidity-typed-uuid ^>= 0.1.0.1
+        - genvalidity-unordered-containers ^>= 1.0.0.1
+        - genvalidity-uuid ^>= 1.0.0.1
+        - genvalidity-vector ^>= 1.0.0.0
+        - mergeful ^>= 0.3.0.0
+        - mergeful-persistent ^>= 0.3.0.1
+        - mergeless ^>= 0.4.0.0
+        - mergeless-persistent ^>= 0.1.0.1
+        - pretty-relative-time ^>= 0.3.0.0
+        - safe-coloured-text ^>= 0.2.0.1
+        - safe-coloured-text-gen ^>= 0.0.0.2
+        - safe-coloured-text-layout ^>= 0.0.0.0
+        - safe-coloured-text-layout-gen ^>= 0.0.0.0
+        - safe-coloured-text-terminfo ^>= 0.1.0.0
+        - sydtest ^>= 0.15.1.1
+        - sydtest-aeson ^>= 0.1.0.0
+        - sydtest-amqp ^>= 0.1.0.0
+        - sydtest-autodocodec ^>= 0.0.0.0
+        - sydtest-discover ^>= 0.0.0.4
+        - sydtest-hedgehog ^>= 0.4.0.0
+        - sydtest-hedis ^>= 0.0.0.0
+        - sydtest-hspec ^>= 0.4.0.2
+        - sydtest-mongo ^>= 0.0.0.0
+        - sydtest-persistent ^>= 0.0.0.2
+        - sydtest-persistent-postgresql < 0
+        - sydtest-persistent-sqlite ^>= 0.2.0.3
+        - sydtest-process ^>= 0.0.0.0
+        - sydtest-rabbitmq ^>= 0.1.0.0
+        - sydtest-servant ^>= 0.2.0.2
+        - sydtest-typed-process ^>= 0.0.0.0
+        - sydtest-wai ^>= 0.2.0.1
+        - sydtest-webdriver ^>= 0.0.0.1
+        - sydtest-webdriver-screenshot ^>= 0.0.0.2
+        - sydtest-webdriver-yesod ^>= 0.0.0.1
+        - sydtest-yesod ^>= 0.3.0.2
+        - typed-uuid ^>= 0.2.0.0
+        - validity ^>= 0.12.0.2
+        - validity-aeson ^>= 0.2.0.5
+        - validity-bytestring ^>= 0.4.1.1
+        - validity-case-insensitive ^>= 0.0.0.0
+        - validity-containers ^>= 0.5.0.4
+        - validity-network-uri ^>= 0.0.0.1
+        - validity-path ^>= 0.4.0.1
+        - validity-persistent ^>= 0.0.0.0
+        - validity-primitive ^>= 0.0.0.1
+        - validity-scientific ^>= 0.2.0.3
+        - validity-text ^>= 0.3.1.3
+        - validity-time ^>= 0.5.0.0
+        - validity-unordered-containers ^>= 0.2.0.3
+        - validity-uuid ^>= 0.1.0.3
+        - validity-vector ^>= 0.2.0.3
+
+
+    "Henry Laxen <nadine.and.henry@pobox.com> @HenryLaxen":
+        - bbdb ^>= 0.8
+
+    "Andrzej Rybczak <andrzej@rybczak.net> @arybczak":
+        - effectful ^>= 2.3.0.0
+        - effectful-core ^>= 2.3.0.1
+        - effectful-plugin ^>= 1.1.0.2
+        - effectful-th ^>= 1.0.0.1
+
+    "Stevan Andjelkovic <stevan.andjelkovic@here.com> @stevana":
+        - quickcheck-state-machine ^>= 0.8.0
+
+    "Sebastian Nagel <sebastian.nagel@ncoding.at> @ch1bo":
+        - hdevtools < 0 # 0.1.8.0 compile fail
+        - servant-exceptions ^>= 0.2.1
+        - servant-exceptions-server ^>= 0.2.1
+
+    "Vaibhav Sagar <vaibhavsagar@gmail.com> @vaibhavsagar":
+        - ihaskell ^>= 0.10.4.0 && <0.11.0.0 # https://github.com/commercialhaskell/stackage/issues/7172
+        - ghc-parser ^>= 0.2.6.0
+
+    "Alexis Williams <alexis@typedr.at> @typedrat":
+        - stb-image-redux < 0 # deprecated version
+
+    "Alexandre Peyroux <alex@px.io> @apeyroux":
+        - HSlippyMap ^>= 3.0.1
+        - google-isbn ^>= 1.0.3
+        - nuxeo ^>= 0.3.2
+
+    "Andrey Sverdlichenko <blaze@ruddy.ru> @rblaze":
+        - credential-store ^>= 0.1.2
+        - dbus ^>= 1.3.1
+        - re2 ^>= 0.3
+
+    "Bardur Arantsson <stackage@scientician.net> @BardurArantsson":
+        - peregrin ^>= 0.4.2
+        - pg-harness-client ^>= 0.6.0
+        - pg-harness-server < 0
+        - tempgres-client ^>= 1.0.0
+        - unliftio-pool < 0
+        - unliftio-streams ^>= 0.2.0.0
+
+    "Sebastian Graf <sgraf1337@gmail.com> @sgraf812":
+        - pomaps < 0
+
+    "Alexey Kotlyarov <a@koterpillar.com> @koterpillar":
+        - appendmap ^>= 0.1.5
+        - serverless-haskell < 0 # 0.12.6 https://github.com/seek-oss/serverless-haskell/issues/188
+
+    "Guru Devanla <grdvnl@gmail.com> @gdevanla":
+        - pptable ^>= 0.3.0.0
+        - cassava-records < 0 # 0.1.0.4 compile fail MonadFail
+        - pandoc-markdown-ghci-filter < 0 # 0.1.0.0 compile fail https://github.com/gdevanla/pandoc-markdown-ghci-filter/issues/3
+
+    "Lucas David Traverso <lucas6246@gmail.com> @ludat":
+        - conferer ^>= 1.1.0.0
+        - conferer-snap < 0
+        - conferer-warp ^>= 1.1.0.1
+        - conferer-hspec < 0
+        - conferer-aeson ^>= 1.1.0.2
+
+    "Tim Humphries <tim+stackage@utf8.me> @thumphries":
+        - transformers-either ^>= 0.1.4
+        - transformers-fix < 0
+
+    "Dan Firth <dan.firth@homotopic.tech> @locallycompact":
+        - aeson-with < 0
+        - binary-instances ^>= 1.0.4
+        - comonad-extras < 0
+        - compact ^>= 0.2.0.0
+        - composite-aeson < 0
+        - composite-aeson-path < 0
+        - composite-aeson-refined < 0
+        - composite-aeson-throw < 0
+        - composite-base ^>= 0.8.2.1 && <0.8.2.2 # https://github.com/commercialhaskell/stackage/issues/7193
+        - composite-binary ^>= 0.8.2.2
+        - composite-ekg < 0
+        - composite-hashable ^>= 0.8.2.2
+        - composite-tuple ^>= 0.1.2.0
+        - composite-xstep ^>= 0.1.0.0
+        - ixset-typed-binary-instance ^>= 0.1.0.2
+        - ixset-typed-conversions < 0
+        - ixset-typed-hashable-instance ^>= 0.1.0.2
+        - lucid-cdn ^>= 0.2.2.0
+        - natural-arithmetic ^>= 0.1.4.0
+        - pandoc-dhall-decoder ^>= 0.1.0.1
+        - pandoc-throw ^>= 0.1.0.0
+        - path-binary-instance ^>= 0.1.0.1
+        - path-dhall-instance ^>= 0.2.1.0
+        - path-extensions ^>= 0.1.1.0
+        - path-formatting < 0
+        - path-like ^>= 0.2.0.2
+        - path-utils ^>= 0.1.1.0
+        - polysemy-extra < 0
+        - polysemy-fs ^>= 0.1.0.0
+        - polysemy-fskvstore < 0
+        - polysemy-kvstore-jsonfile < 0
+        - polysemy-kvstore < 0
+        - polysemy-methodology < 0
+        - polysemy-path < 0
+        - polysemy-several < 0
+        - polysemy-socket < 0
+        - polysemy-uncontrolled < 0
+        - polysemy-video < 0
+        - polysemy-vinyl < 0
+        - primitive-offset ^>= 0.2.0.0
+        - sdl2-gfx ^>= 0.3.0.0
+        - sdl2-image ^>= 2.1.0.0
+        - sdl2-mixer ^>= 1.2.0.0
+        - shake-plus ^>= 0.3.4.0
+        - shake-plus-extended ^>= 0.4.1.0
+        - simple-media-timestamp ^>= 0.2.1.0
+        - simple-media-timestamp-formatting < 0
+        - simple-media-timestamp-attoparsec ^>= 0.1.0.0
+        - srt ^>= 0.1.2.0
+        - srt-attoparsec < 0
+        - srt-dhall < 0
+        - srt-formatting < 0
+        - tuples ^>= 0.1.0.0
+        - unliftio-path ^>= 0.0.2.0
+        - variable-media-field < 0
+        - variable-media-field-dhall < 0
+        - variable-media-field-optics < 0
+        - vinyl-loeb ^>= 0.0.1.0
+        - within ^>= 0.2.0.1
+        - zipper-extra < 0
+
+    "Domen Kozar <domen@enlambda.com> @domenkozar":
+        - elm2nix < 0 # 0.3.0 compile fail
+        - mixpanel-client < 0 # 0.3.0 aeson 2, https://github.com/commercialhaskell/stackage/issues/6443
+        - pretty-sop ^>= 0.2.0.3
+        - servant-auth ^>= 0.4.1.0
+        - servant-auth-server ^>= 0.4.8.0
+        - servant-auth-client ^>= 0.4.1.1
+        - servant-auth-swagger ^>= 0.2.10.2
+        - servant-auth-docs ^>= 0.2.10.1
+        - servant-elm ^>= 0.7.3
+        - systemd ^>= 2.3.0
+
+    "Andre Van Der Merwe <stackage@andrevdm.com> @andrevdm":
+        - bhoogle < 0
+        - hyraxAbif ^>= 0.2.4.5
+        - postgresql-migration ^>= 0.2.1.7
+
+    "David Millar-Durrant <dmillardurrant@gmail.com> @DavidM-D":
+        - indexed-list-literals ^>= 0.2.1.3
+
+    "Dmitry Dzhus <dima@dzhus.org> @dzhus":
+        - csg < 0
+        - simple-vec3 ^>= 0.6.0.1
+        - static-text ^>= 0.2.0.7
+        - th-env ^>= 0.1.1
+        - th-nowq ^>= 0.1.0.5
+
+    "Dan Fithian <daniel.m.fithian@gmail.com> @dfithian":
+        - oauthenticated < 0 # 0.3.0.0 compile fail https://github.com/tel/oauthenticated/issues/33
+        - datadog ^>= 0.3.0.0
+        - interpolator < 0
+        - file-path-th ^>= 0.1.0.0
+
+    "Raghu Kaippully <rkaippully@gmail.com> @rkaippully":
+        - webgear-core < 0 # https://github.com/commercialhaskell/stackage/issues/7168
+        - webgear-openapi < 0 # https://github.com/commercialhaskell/stackage/issues/7168
+        - webgear-server < 0 # 1.0.5 compile fail https://github.com/haskell-webgear/webgear/issues/16
+
+    "Alex Washburn <github@recursion.ninja> @recursion-ninja":
+        - bv-little ^>= 1.3.2
+        - mono-traversable-keys ^>= 0.3.0
+
+    "Avi Press <mail@avi.press> @aviaviavi":
+        - curl-runnings < 0
+        - cryptocompare ^>= 0.1.2
+
+    "Jack Kiefer <jack.c.kiefer@gmail.com> @JackKiefer":
+        - herms < 0
+
+    "Sergey Vinokurov <serg.foo@gmail.com> @sergv":
+        - bencoding < 0 # 0.4.5.4 compile fail not ghc-9.6 ready https://github.com/sergv/bencoding/issues/4
+        - emacs-module ^>= 0.2.1
+        - tasty-ant-xml ^>= 1.1.9
+        - prettyprinter-combinators ^>= 0.1.2
+        - composition-prelude ^>= 3.0.0.2
+        - toml-reader-parse ^>= 0.1.1.1
+        - atomic-counter ^>= 0.1.2.1
+        - directory-ospath-streaming ^>= 0.1.0.1
+
+    "Eugene Smolanka <esmolanka@gmail.com> @esmolanka":
+        - sexp-grammar ^>= 2.3.4.2
+        - invertible-grammar ^>= 0.1.3.5
+
+    "Maximilian Tagher <feedback.tagher@gmail.com> @MaxGabriel":
+        - aeson-iproute ^>= 0.3.0
+        - persistent-iproute ^>= 0.2.5
+
+    "Damian Nadales <damian.nadales@gmail.com> @capitanbatata":
+        - hierarchy < 0
+
+    "Kofi Gumbs <h.kofigumbs@gmail.com> @hkgumbs":
+        - codec-beam ^>= 0.2.0
+
+    "Chris Parks <christopher.daniel.parks@gmail.com> @cdparks":
+        - closed ^>= 0.2.0.2
+
+    "Chris Coffey <chris@foldl.io> @ChrisCoffey":
+        - servant-tracing < 0
+        - cuckoo-filter < 0
+        - confcrypt < 0
+
+    "Rick Owens <rick@owensmurray.com> @owensmurray":
+        - om-elm ^>= 2.0.0.5
+
+    "ALeX Kazik <alex@kazik.de> @alexkazik":
+        - exomizer ^>= 1.0.0
+        - qnap-decrypt < 0
+        - qrcode-core ^>= 0.9.9
+        - qrcode-juicypixels ^>= 0.8.5
+
+    "Reed Oei <oei.reed@gmail.com> @ReedOei":
+        - fuzzy-dates ^>= 0.1.1.2
+
+    "Matthew Farkas-Dyck <strake888@gmail.com> @strake":
+        - Fin < 0
+        - alg < 0
+        - category < 0
+        - constraint < 0
+        - dual < 0 # 0.1.1.1 compile fail deprecated (https://hackage.haskell.org/package/dual) and not ghc 9.6 ready
+        - either-both < 0 # 0.1.1.1 compile fail deprecated (https://hackage.haskell.org/package/either-both) and not ghc 9.6 ready
+        - filtrable ^>= 0.1.6.0
+        - foldable1 < 0
+        - hs-functors < 0
+        - lenz < 0
+        - natural-induction ^>= 0.2.0.0
+        - peano ^>= 0.1.0.2
+        - unconstrained ^>= 0.1.0.2
+        - util < 0 # 0.1.17.1 compile fail needs DerivingVia enabled
+
+    "Ben Sima <ben@bsima.me> @bensima":
+        - yesod-text-markdown < 0
+
+    "Alexander Krupenkin <mail@akru.me> @akru":
+        - web3 < 0
+
+    "Georg Rudoy <0xd34df00d@gmail.com> @0xd34df00d":
+        - binary-generic-combinators ^>= 0.4.4.0
+        - can-i-haz ^>= 0.3.1.1
+        - enum-subset-generate ^>= 0.1.0.1
+
+    "Trevis Elser <trevis@silencedpoet.com> @telser":
+        - sendfile ^>= 0.7.11.5
+
+    "Kristen Kozak <grayjay@wordroute.com> @grayjay":
+        - json-rpc-server < 0
+        - json-rpc-client < 0
+
+    "Magnus Therning <magnus@therning.org> @magthe":
+        - hsini ^>= 0.5.2.2
+
+    "Baojun Wang <wangbj@gmail.com> @wangbj":
+        - elf ^>= 0.31
+
+    "Tom Oram <tom@x2k.co.uk> @tomphp":
+        - cfenv ^>= 0.1.0.0
+
+    "Owen Lynch <root@owenlynch.org> @olynch":
+        - natural-sort ^>= 0.1.2
+
+    "John Biesnecker <jbiesnecker@gmail.com> @biesnecker":
+        - async-pool ^>= 0.9.2
+
+    "Zoltan Kelemen <kelemzol@elte.hu> @kelemzol":
+        - fswatch < 0
+
+    "Matthew Wraith <matt@bitnomial.com> @wraithm":
+        - prometheus ^>= 2.2.4
+        - prometheus-wai-middleware < 0
+        - hgrev < 0
+        - seqid ^>= 0.6.3
+        - seqid-streams ^>= 0.7.2
+
+    "Daniel Gorin <jcpetruzza@gmail.com> @jcpetruzza":
+        - barbies ^>= 2.0.5.0
+        - data-hash ^>= 0.2.0.1
+
+    "Eduard Sergeev <eduard.sergeev@gmail.com> @EduardSergeev":
+        - monad-memo ^>= 0.5.4
+
+    "Wanja Chresta <wanja.hs@chrummibei.ch> @wchresta":
+        - matrix-static ^>= 0.3
+
+    "Jean-Pierre Rupp <xenog@protonmail.com> @xenog":
+        - json-rpc ^>= 1.0.4
+        - rfc1751 ^>= 0.1.3
+        - murmur3 ^>= 1.0.5
+        - nqe ^>= 0.6.5
+        - secp256k1-haskell ^>= 1.1.0
+        - rocksdb-haskell ^>= 1.0.1
+        - rocksdb-haskell-jprupp ^>= 2.1.6
+        - rocksdb-query ^>= 0.4.2
+        - haskoin-core ^>= 1.0.2
+        - haskoin-node ^>= 1.0.1
+        - haskoin-store < 0
+
+    "asakamirai <asakamirai_hackage@towanowa.net> @asakamirai":
+        - kazura-queue ^>= 0.1.0.4
+
+    "Eric Torreborre <etorreborre@yahoo.com> @etorreborre":
+        - registry < 0
+        - registry-aeson < 0
+        - registry-hedgehog < 0
+        - registry-hedgehog-aeson < 0
+        - registry-options < 0
+
+    "Ryota Kameoka <kameoka.ryota@gmail.com> @ryota-ka":
+        - duration ^>= 0.2.0.0
+
+    "Takenobu Tani <takenobu.hs@gmail.com> @takenobu-hs":
+        - ghci-hexcalc ^>= 0.1.1.0
+
+    "Nikos Karagianndis <nkarag@gmail.com> @nkarag":
+        - DBFunctor ^>= 0.1.2.1
+
+    "Marat Khafizov <xafizoff@gmail.com> @xafizoff":
+        - n2o ^>= 0.11.1
+        - n2o-nitro ^>= 0.11.2
+        - n2o-protocols < 0
+        - n2o-web < 0
+
+    "David Smith <shmish111@gmail.com> @shmish111":
+        - bazel-runfiles ^>= 0.12
+
+    "Rob Rix <robrix@github.com> @robrix":
+        - fused-effects ^>= 1.1.2.2
+
+    "Josef Thorne <joseft.168@gmail.com> @Grendel-Grendel-Grendel":
+        - focuslist ^>= 0.1.1.0
+
+    "Pavan Rikhi <pavan.rikhi@gmail.com> @prikhi":
+        - hs-php-session ^>= 0.0.9.3
+        - wordpress-auth < 0 # 1.0.0.1 # fails to compile https://github.com/prikhi/wordpress-auth/issues/1
+        - servant-auth-wordpress < 0
+        - ca-province-codes ^>= 1.0.0.0
+        - mx-state-codes ^>= 1.0.0.0
+        - sitemap-gen ^>= 0.1.0.0
+        - tasty-wai ^>= 0.1.2.0
+        - stack-templatizer ^>= 0.1.1.0
+        - immortal-queue ^>= 0.1.0.1
+        - wai-middleware-clacks ^>= 0.1.0.1
+        - hledger-stockquotes ^>= 0.1.2.1
+        - bnb-staking-csvs ^>= 0.2.1.0
+        - solana-staking-csvs ^>= 0.1.2.0
+        - cointracking-imports ^>= 0.1.0.2
+        - binance-exports ^>= 0.1.2.0
+        - gemini-exports ^>= 0.1.0.0
+
+    "David Baynard <haskell@baynard.dev> @dbaynard":
+        - time-qq < 0
+        - ucam-webauth < 0
+        - ucam-webauth-types < 0
+
+    "Erick Gonzalez <erick@codemonkeylabs.de> @codemonkeylabs-de":
+        - eap ^>= 0.9.0.2
+        - failable < 0
+        - ttl-hashtables < 0
+        - radius ^>= 0.7.1.0
+        - structured-cli < 0
+
+    "Jan Path <jan@jpath.de> @janpath":
+        - smallcheck-series < 0
+
+    "Taisuke Hikawa <23.prime.37@gmail.com> @23prime":
+        - oeis2 < 0 # 1.0.7 compile fail https://github.com/commercialhaskell/stackage/issues/6498
+
+    "David Himmelstrup <lemmih@gmail.com> @lemmih":
+        - chiphunk < 0
+        - reanimate-svg < 0 # https://github.com/reanimate/reanimate-svg/issues/41
+        - reanimate < 0
+        - earcut < 0
+        - vector-circular < 0
+        - hgeometry < 0
+        - hgeometry-combinatorial < 0
+        - approximate-equality ^>= 1.1.0.2 # required by hgeometry-combinatorial
+        - type-level-natural-number ^>= 2.0 # required by approximate-equality
+
+    "Vitaly Bragilevsky <vit.bragilevsky@gmail.com> @bravit":
+        - Chart ^>= 1.9.5
+        - Chart-diagrams ^>= 1.9.5.1
+
+    "Juri Chomé <juri.chome@gmail.com> @2mol":
+        - msgpack ^>= 1.0.1.0
+        - msgpack-rpc < 0
+        - msgpack-idl < 0
+        - msgpack-aeson < 0 # 0.1.0.0 compile fail https://github.com/commercialhaskell/stackage/issues/7135
+        - int-cast ^>= 0.2.0.0
+
+    "Akihito Kirisaki <kirisaki@klaraworks.net> @kirisaki":
+        - caster < 0
+
+    "Felix Paulusma <felix.paulusma@gmail.com> @Vlix":
+        - safe-json ^>= 1.2.0.0
+
+    "Olle Fredriksson <fredriksson.olle@gmail.com> @ollef":
+        - rope-utf16-splay ^>= 0.4.0.0
+
+    "Venkateswara Rao Mandela <venkat.mandela@gmail.com> @vmandela":
+        - pandoc-csv2table < 0
+
+    "Elben Shira <elben@shira.im> @elben":
+        - pencil < 0
+
+    "Ivan Malison <IvanMalison@gmail.com> @IvanMalison":
+        - ConfigFile < 0
+        - dbus-hslogger ^>= 0.1.0.1
+        - gi-cairo-connector < 0
+        - gi-cairo-render ^>= 0.1.2
+        - gtk-sni-tray < 0
+        - gtk-strut ^>= 0.1.3.2
+        - rate-limit ^>= 1.4.3
+        - status-notifier-item ^>= 0.3.1.0
+        - taffybar < 0
+        - time-units ^>= 1.0.0
+        - xml-helpers ^>= 1.0.0
+        - xdg-desktop-entry < 0
+
+    "ARATA Mizuki <minorinoki@gmail.com> @minoki":
+        - unboxing-vector ^>= 0.2.0.0
+
+    "Brandon Chinn <brandonchinn178@gmail.com> @brandonchinn178":
+        - aeson-schemas ^>= 1.4.1.0
+        - fourmolu ^>= 0.14.0.0
+        - github-rest ^>= 1.1.4
+        - graphql-client ^>= 1.2.2
+        - hpc-lcov ^>= 1.1.1
+        - http-api-data-qq ^>= 0.1.0.0
+        - persistent-mtl < 0
+        - tasty-autocollect ^>= 0.4.1
+        - th-test-utils ^>= 1.2.1
+        - toml-reader ^>= 0.2.1.0
+
+    "Akshay Mankar <itsakshaymankar@gmail.com> @akshaymankar":
+        - jsonpath ^>= 0.3.0.0
+
+    "James Brock <jamesbrock@gmail.com> @jamesdbrock":
+        - replace-megaparsec ^>= 1.5.0.1
+        - replace-attoparsec ^>= 1.5.0.0
+
+    "Robbie McMichael @robbiemcmichael":
+        - http-client-overrides ^>= 0.1.1.0
+
+    "Ian Graves <thegravian@gmail.com> @igraves":
+        - monad-resumption ^>= 0.1.4.0
+
+    "Marius Ghita <mhitza@gmail.com> @mhitza":
+        - minimal-configuration ^>= 0.1.4
+
+    "Davit Nalchevanidze <d.nalchevanidze@gmail.com> @nalchevanidze":
+        - morpheus-graphql < 0
+        - morpheus-graphql-core ^>= 0.27.3
+        - morpheus-graphql-client ^>= 0.27.3
+        - morpheus-graphql-subscriptions ^>= 0.27.3
+        - morpheus-graphql-app ^>= 0.27.3
+        - morpheus-graphql-code-gen < 0
+        - morpheus-graphql-tests ^>= 0.27.3
+        - morpheus-graphql-code-gen-utils ^>= 0.27.3
+        - morpheus-graphql-server ^>= 0.27.3
+
+    "Satoshi Egi <egi@egison.org> @egisatoshi":
+        - backtracking ^>= 0.1.0
+        - egison < 0
+        - mini-egison < 0
+        - sweet-egison < 0
+        - egison-pattern-src ^>= 0.2.1.2
+        - egison-pattern-src-th-mode < 0
+
+    "Travis Cardwell <travis.cardwell@extrema.is> @TravisCardwell":
+        - bm ^>= 0.2.0.0
+        - horizontal-rule ^>= 0.6.0.0
+        - literatex ^>= 0.3.0.0
+        - phatsort ^>= 0.6.0.0
+        - queue-sheet < 0
+        - redact ^>= 0.5.0.0
+        - ttc ^>= 1.4.0.0
+
+    "Jasper Woudenberg <mail@jasperwoudenberg.com> @jwoudenberg":
+        - bugsnag-hs ^>= 0.2.0.12
+        - junit-xml ^>= 0.1.0.3
+        - wai-feature-flags ^>= 0.1.0.7
+        - tasty-test-reporter < 0
+        - pretty-diff < 0
+
+    "Eric Conlon <ejconlon@gmail.com> @ejconlon":
+        - blanks ^>= 0.5.0
+        - climb < 0
+        - linenoise < 0
+        - little-rio ^>= 2.0.1
+        - little-logger ^>= 1.0.2
+        # Maintainership with @23Skidoo
+        - ekg < 0
+        - ekg-core ^>= 0.1.1.7
+        - ekg-json < 0
+        - ekg-statsd < 0
+
+    "Jorah Gao <jorah@version.cloud> @gqk007":
+        - aeson-default < 0
+        - vformat ^>= 0.14.1.0
+        - vformat-time ^>= 0.1.0.0
+        - vformat-aeson < 0
+        - hkd-default ^>= 1.1.0.0
+
+    "Shintaro Sakata <shintaro.sakata.tokyo@gmail.com> @chemirea":
+        - utf8-conversions < 0
+
+    "Alessandro Marrella <amarrella@earnestresearch.com> @amarrella":
+        - kubernetes-webhook-haskell < 0
+
+    "8c6794b6 <8c6794b6@gmail.com> @8c6794b6":
+        - hpc-codecov ^>= 0.5.0.0
+        - miniterion ^>= 0.1.1.0
+
+    "Hiromi Ishii <konn.jinro@gmail.com> @konn":
+        - equational-reasoning ^>= 0.7.0.1
+        - ghc-typelits-presburger ^>= 0.7.2.0
+        - singletons-presburger ^>= 0.7.2.0
+        - type-natural ^>= 1.3.0.0
+        - subcategories ^>= 0.2.0.1
+        - sized ^>= 1.1.0.0
+
+    "Frank Doepper <stackage@woffs.de> @woffs":
+        - amqp-utils ^>= 0.6.4.0
+        - magic ^>= 1.1
+
+    "Ziyang Liu <free@cofree.io> @zliu41":
+        - apply-refact ^>= 0.13.0.0
+        - hadoop-streaming < 0
+        - indexed-containers ^>= 0.1.0.2
+        - math-extras ^>= 0.1.1.0
+        - min-max-pqueue ^>= 0.1.0.2
+        - multi-containers ^>= 0.2
+
+    "Vaclav Svejcar <vaclav.svejcar@gmail.com> @vaclavsvejcar":
+        - headroom < 0 # 0.4.3.0 compile fail
+        - vcs-ignore ^>= 0.0.2.0
+
+    "Adrian Sieber <stackage@ad-si.com> @ad-si":
+        - ulid ^>= 0.3.2.0
+
+    "Rickey Visinski <rickeyvisinski+hs@gmail.com> @rickeyski":
+        - slack-api < 0
+
+    "Dobromir Nikolov <dnikolovv@hotmail.com> @dnikolovv":
+        - it-has < 0
+
+    "Gabriele Sales <gbrsales@gmail.com> @gbrsales":
+        - cabal-appimage ^>= 0.4.0.2
+
+    "Dominik Schrempf <dominik.schrempf@gmail.com> @dschrempf":
+        - circular ^>= 0.4.0.3
+        - covariance ^>= 0.2.0.1
+        - dirichlet ^>= 0.1.0.7
+        - elynx ^>= 0.7.2.2
+        - elynx-markov ^>= 0.7.2.2
+        - elynx-nexus ^>= 0.7.2.2
+        - elynx-seq ^>= 0.7.2.2
+        - elynx-tools ^>= 0.7.2.2
+        - elynx-tree ^>= 0.7.2.2
+        - glasso ^>= 0.1.0
+        - mcmc ^>= 0.8.2.0
+        - pava ^>= 0.1.1.4
+        - slynx ^>= 0.7.2.2
+        - tlynx ^>= 0.7.2.2
+
+    "Eric Rochester <erochest@gmail.com> @erochest":
+        - text-regex-replace ^>= 0.1.1.5
+
+    "Masahiro Honma <hiratara@cpan.org> @hiratara":
+        - string-random ^>= 0.1.4.3
+
+    "Michael B. Gale <github@michael-gale.co.uk> @mbg":
+        - c14n ^>= 0.1.0.3
+        - katip-logstash ^>= 0.1.0.2
+        - logstash ^>= 0.1.0.4
+        - monad-logger-logstash ^>= 0.2.0.2
+        - moss ^>= 0.2.0.1
+        - network-wait ^>= 0.2.0.0
+        - servant-rate-limit ^>= 0.2.0.0
+        - time-units-types ^>= 0.2.0.1
+        - wai-rate-limit ^>= 0.3.0.0
+        - wai-rate-limit-redis ^>= 0.2.0.1
+        - wai-saml2 ^>= 0.5
+
+    "Jun Narumi <narumij@gmail.com> @narumij":
+        - matrix-as-xyz ^>= 0.1.2.2
+        - hall-symbols ^>= 0.1.0.6
+        - symmetry-operations-symbols ^>= 0.0.2.1
+
+    "Hideaki Kawai  <kayhide@gmail.com> @kayhide":
+        - wakame ^>= 0.1.0.0
+
+    "Michael Williams <mlcfp@icloud.com> @mlcfp":
+        - zenacy-html ^>= 2.1.0
+        - zenacy-unicode ^>= 1.0.2
+
+    "Maxim Koltsov <kolmax94@gmail.com> @maksbotan":
+        - openapi3 ^>= 3.2.4
+        - servant-openapi3 ^>= 2.0.1.6
+
+    "Song Zhang <HaskellZhangSong@hotmail.com> @HaskellZhangSong":
+        - derive-topdown ^>= 0.0.3.0
+
+    "NoRedInk <haskell-open-source@noredink.com>":
+        - nri-env-parser < 0
+        - nri-http < 0
+        - nri-kafka < 0
+        - nri-observability < 0
+        - nri-prelude < 0
+        - nri-postgresql < 0
+        - nri-redis < 0
+        - nri-test-encoding < 0
+
+    "Peter Lebbing <peter@digitalbrains.com> @DigitalBrains1":
+        - prettyprinter-interp ^>= 0.2.0.0
+
+    "Behrang Norouzinia <behrangn@gmail.com> @behrang":
+        - jalaali ^>= 1.0.0.0
+
+    "Alexander Batischev <eual.jp@gmail.com> @Minoru":
+        - hakyll-convert ^>= 0.3.0.4
+
+    "Edward Nerd <nerded.nerded@gmail.com> @nerded1337":
+        - zydiskell < 0
+
+    "Alejandro Peralta Bazas <aleperaltabazas@gmail.com> @aleperaltabazas":
+        - hocon < 0
+
+    "Joshua Booth <joshua.n.booth@gmail.com> @jnbooth":
+        - bitwise-enum ^>= 1.0.1.2
+
+    "Shlomo Shuck <stevenjshuck@gmail.com> @sjshuck":
+        - pcre2 ^>= 2.2.1
+
+    "Emil Axelsson <78emil@gmail.com> @emax":
+        - tree-view ^>= 0.5.1
+
+    "Samuel Gélineau <gelisam@gmail.com> @gelisam":
+        - haskell-awk < 0
+        - hint ^>= 0.9.0.8
+        - recursion-schemes ^>= 5.2.2.5
+
+    "Kyriakos Papachrysanthou <k.papachrisanthou@gmail.com> @3kyro":
+        - keep-alive ^>= 0.2.1.0
+
+    "Brooklyn Zelenka <hello@brooklynzelenka.com> @expede":
+        - rescue < 0
+
+    "Artem Pelenitsyn <artem.pelenitsyn@gmail.com> @ulysses4ever":
+        - alex-meta ^>= 0.3.0.13
+        - happy-meta ^>= 0.2.1.0
+        - BNFC-meta ^>= 0.6.1
+        - vector-hashtables ^>= 0.1.1.4
+
+    "Tomasz Maciosowski <t4ccer@gmail.com> @t4ccer":
+        - wai-session-redis ^>= 0.1.0.5
+
+    "Rory Tyler Hayford <rory.hayford@protonmail.com> @ngua":
+        - ipa < 0
+
+    "Andreas Herrmann <andreas.herrmann@tweag.io> @aherrmann":
+        - capability < 0 # https://github.com/commercialhaskell/stackage/issues/7146
+
+    "Dustin Sallings <dustin@spy.net> @dustin":
+        - net-mqtt ^>= 0.8.6.0
+        - net-mqtt-lens ^>= 0.1.1.0
+
+    "David A Roberts <d@vidr.cc> @davidar":
+        - streamt < 0
+
+    "Martin Sosic <sosic.martin@gmail.com> @Martinsos":
+        - strong-path < 0
+
+    "Arnaud Spiwack <arnaud.spiwack@tweag.io> @aspiwack":
+        - linear-base ^>= 0.4.0
+        - linear-generics ^>= 0.2.2
+
+    "Ollie Charles <ollie@ocharles.org.up> @ocharles":
+        - reactive-banana ^>= 1.3.2.0
+        - rel8 < 0
+        - logging-effect ^>= 1.4.0
+
+    "Grzegorz Milka <grzegorzmilka@gmail.com> @gregorias":
+        - trimdent ^>= 0.1.0.0
+
+    "xmonad <xmonad@haskell.org>":
+        - X11 ^>= 1.10.3
+        - xmonad ^>= 0.17.2
+        - xmonad-contrib < 0
+
+    "Marcellus Siegburg <marcellus.siegburg@gmail.com> @marcellussiegburg":
+        - call-alloy ^>= 0.4.0.3
+        - call-plantuml ^>= 0.0.1.3
+        - hgal ^>= 2.0.0.3
+
+    "Rickard Andersson <gonz@severnatazvezda.com> @GoNZooo":
+        - reddit-scrape ^>= 0.0.1
+
+    "James Cranch <cranch@cantab.net> @jcranch":
+        - agreeing ^>= 0.2.2.0
+        - mappings ^>= 0.3.0.0
+        - partialord ^>= 0.0.2
+        - tophat ^>= 1.0.7.0
+
+    "Jan Synacek <jan.synacek@scrive.com> @jsynacek":
+        - hpqtypes ^>= 1.11.1.2
+        - hpqtypes-extras ^>= 1.16.4.4
+        - fields-json ^>= 0.4.0.0
+        - log-base ^>= 0.12.0.1
+        - unjson ^>= 0.15.4
+
+    "Daan Leijen <daan@effp.org> @daanx":
+        - isocline ^>= 1.0.9
+
+    "Chase <totallynotchase42@@gmail.com> @TotallyNotChase":
+        - valida ^>= 1.1.0
+        - valida-base ^>= 0.2.0
+
+    "Andrew Miller <andrew@amxl.com> @A1kmm":
+        - polysemy-webserver ^>= 0.2.1.2
+
+    "Simon Shine <shreddedglory@gmail.com> @sshine":
+        - evm-opcodes ^>= 0.1.2
+
+    "Francesco Ariis <fa-ml@ariis.it> @ffaf1":
+        - ansi-terminal-game ^>= 1.9.2.0
+        - lentil ^>= 1.5.6.0
+        - linebreak ^>= 1.1.0.4
+        - timers-tick ^>= 0.5.0.4
+        - unidecode ^>= 0.1.0.4
+
+    "Chris Smith <cdsmith@gmail.com>":
+        - HMock ^>= 0.5.1.2
+        - explainable-predicates ^>= 0.1.2.4
+
+    "Tim Emiola <tim.emiola@gmail.com> @adetokunbo":
+        - benri-hspec ^>= 0.1.0.1
+        - attoparsec-framer ^>= 0.1.0.1
+        - hspec-tmp-proc ^>= 0.5.2.0
+        - keyed-vals ^>= 0.2.2.0
+        - keyed-vals-hspec-tests ^>= 0.2.2.0
+        - keyed-vals-mem ^>= 0.2.2.0
+        - keyed-vals-redis ^>= 0.2.2.0
+        - redis-glob ^>= 0.1.0.6
+        - tmp-proc ^>= 0.5.3.0
+        - tmp-proc-postgres ^>= 0.5.3.1
+        - tmp-proc-redis ^>= 0.5.3.1
+        - tmp-proc-rabbitmq ^>= 0.5.3.1
+        - wai-middleware-delegate ^>= 0.1.4.0
+
+    "Francisco Vallarino <fjvallarino@gmail.com> @fjvallarino":
+        - monomer ^>= 1.6.0.0
+        - nanovg ^>= 0.8.1.0
+
+    "Ghais Issa <0x47@0x49.dev> @ghais":
+        - LetsBeRational ^>= 1.0.0.0
+
+    "Edward Yang <qwbarch@gmail.com> @qwbarch":
+        - captcha-core < 0
+        - captcha-2captcha < 0
+        - captcha-capmonster < 0
+        - data-default-extra < 0
+        - data-default-instances-base ^>= 0.1.0.1
+        - data-default-instances-bytestring ^>= 0.0.1
+        - data-default-instances-case-insensitive ^>= 0.0.1
+        - data-default-instances-new-base < 0
+        - data-default-instances-text < 0
+        - data-default-instances-unordered-containers ^>= 0.0.1
+        - data-default-instances-vector ^>= 0.0.1
+        - optics-operators ^>= 0.1.0.1
+
+    "David Spies <dnspies@gmail.com> @davidspies":
+        - fastmemo < 0
+
+    "comp <onecomputer00@gmail.com> @1Computer1":
+        - errata ^>= 0.4.0.1
+        - reorder-expression < 0
+
+    "konsumlamm <konsumlamm@gmail.com> @konsumlamm":
+        - rrb-vector ^>= 0.2.1.0
+
+    "Co-Star Astrology Society <tech@costarastrology.com> @costarastrology @halawaykeller":
+        - Plural ^>= 0.0.2
+        - bytebuild ^>= 0.3.14.0
+        - byteslice ^>= 0.2.12.0
+        - contiguous ^>= 0.6.4.0
+        - fb ^>= 2.1.1.1
+        - ip ^>= 1.7.7
+        - pwstore-fast ^>= 2.4.4
+        - rex ^>= 0.6.2
+        - run-st ^>= 0.1.3.2
+        - text-regex-replace ^>= 0.1.1.5
+        - word-compat ^>= 0.0.6
+        - zigzag ^>= 0.0.1.0
+
+    "Markus  Schirp <mbj@schirp-dso.com> @mbj":
+        - stratosphere ^>= 0.60.0
+
+    "Clemens Schmid <clemens@nevrome.de> @nevrome":
+        - currycarbon ^>= 0.3.0.1
+
+    "Benjamin Orchard <thefirstmuffinman@gmail.com> @raehik":
+        - flatparse ^>= 0.5.0.1
+        - strongweak < 0
+        - mason ^>= 0.2.6
+        - fortran-src-extras < 0
+
+    "David Terei <code@davidterei.com> @dterei":
+        - memcache ^>= 0.3.0.1
+
+    "Teo Camarasu <teofilcamarasu@gmail.com> @TeofilC":
+        - bank-holidays-england ^>= 0.2.0.9
+        - statistics-linreg ^>= 0.3
+        - trie-simple ^>= 0.4.2
+        - PSQueue ^>= 1.2.0
+        - matchable ^>= 0.1.2.1 # dep of trie-simple
+
+    "Fabricio Olivetti de Franca <fabricio.olivetti@gmail.com> @folivetti":
+        - hegg ^>= 0.5.0.0 # dep of pandoc-symreg
+        - pandoc-symreg < 0
+        - srtree ^>= 1.0.0.5
+
+    "Eugen Wissner <belka@caraus.de> @belka-ew":
+        - graphql ^>= 1.2.0.1
+
+    "Mike Pilgrem <public@pilgrem.com> @mpilgrem":
+        - aeson-warning-parser ^>= 0.1.1
+        - ansi-terminal ^>= 1.0
+        - ansi-terminal-types ^>= 0.11.5
+        - companion ^>= 0.1.0
+        - stack ^>= 2.13.1 && (<9.9.9 || >9.9.9)
+        - static-bytes ^>= 0.1.0
+
+    "Torsten Schmits <stackage@schmits.me> @tek":
+        - exon ^>= 1.6.1.0
+        - incipit-base ^>= 0.5.1.0
+        - incipit-core ^>= 0.5.1.0
+        - polysemy ^>= 1.9.1.3
+        - polysemy-plugin ^>= 0.4.5.1
+        - polysemy-zoo < 0
+
+    "Michael Dressel <michael.dressel@kloenplatz.de> @mdrslmr":
+        - MultipletCombiner ^>= 0.0.7
+
+    "Kazu Yamamoto <kazu@iij.ad.jp> @kazu-yamamoto":
+        - crypton ^>= 0.34
+        - crypton-connection ^>= 0.3.1
+        - crypton-x509 ^>= 1.7.6
+        - crypton-x509-store ^>= 1.6.9
+        - crypton-x509-system ^>= 1.6.7
+        - crypton-x509-validation ^>= 1.6.12
+        - http2 ^>= 5.0.0
+        - network-control ^>= 0.0.2
+
+    "Patrick Nielsen <github@patrickmn.com> @patrickmn":
+        - aeson-yaml ^>= 1.1.0.1
+
+    "Eric Mertens <emertens@gmail.com> @glguy":
+        - toml-parser ^>= 1.3.1.1
+
+    "Andreas Ländle @alaendle":
+        - co-log ^>= 0.6.0.2
+        - co-log-core ^>= 0.3.2.1
+        - co-log-polysemy ^>= 0.0.1.4
+
+    "Alexander Esgen <amesgen@amesgen.de> @amesgen":
+        - ghc-hs-meta ^>= 0.1.3.0
+
+    "Ian Davidson <bontaq@gmail.com> @bontaq":
+        - purview ^>= 0.2.0.2
+
+    "Logan McGrath <logan.mcgrath@thisfieldwas.green> @keywordsalad":
+        - hakyllbars ^>= 1.0.1.0
+
+    "David Sánchez <davidslt+stackage@pm.me> @DavSanchez":
+        - richenv ^>= 0.1.0.1
+
+    "Zac Slade <krakrjak@gmail.com> @krakrjak":
+        - fits-parse ^>= 0.3.6
+
+    "Grandfathered dependencies":
+        - BiobaseNewick ^>= 0.0.0.2
+        - Boolean ^>= 0.2.4
+        - BoundedChan ^>= 1.0.3.0
+        - Chart-cairo ^>= 1.9.4.1
+        - Decimal ^>= 0.5.2
+        - Diff ^>= 0.4.1
+        - FloatingHex ^>= 0.5
+        - GenericPretty ^>= 1.2.2
+        - Glob ^>= 0.10.2
+        - HDBC ^>= 2.4.0.4
+        - HDBC-session ^>= 0.1.2.1
+        - HTTP ^>= 4000.4.1
+        - HasBigDecimal ^>= 0.2.0.0
+        - HsOpenSSL ^>= 0.11.7.6
+        - IfElse ^>= 0.85
+        - Interpolation ^>= 0.3.0
+        - JuicyPixels-scale-dct ^>= 0.1.2
+        - MemoTrie ^>= 0.6.11
+        - NoHoed ^>= 0.1.1
+        - NumInstances ^>= 1.4
+        - Only ^>= 0.1
+        - ParsecTools ^>= 0.0.2.0
+        - QuickCheck ^>= 2.14.3
+        - RSA ^>= 2.4.1
+        - Stream ^>= 0.4.7.2
+        - TypeCompose < 0
+        - Yampa ^>= 0.14.6
+        - accelerate-io-bmp < 0
+        - accelerate-io-bytestring < 0
+        - accelerate-io-repa < 0
+        - accelerate-io-vector < 0
+        - aeson-extra ^>= 0.5.1.3
+        - aeson-optics ^>= 1.2.1
+        - alsa-mixer ^>= 0.3.0.1
+        - animalcase < 0
+        - appar ^>= 0.1.8
+        - arrows ^>= 0.4.4.2
+        - asn1-encoding ^>= 0.9.6
+        - asn1-parse ^>= 0.9.5
+        - asn1-types ^>= 0.3.4
+        - assoc ^>= 1.1
+        - attoparsec ^>= 0.14.4
+        - attoparsec-aeson ^>= 2.1.0.0
+        - auto-update ^>= 0.1.6
+        - aws ^>= 0.24.1
+        - aws-lambda-haskell-runtime-wai < 0
+        - base-noprelude < 0
+        - base64-bytestring ^>= 1.2.1.0
+        - base64-bytestring-type ^>= 1.0.1
+        - base64-string ^>= 0.2
+        - bimap ^>= 0.5.0
+        - bin ^>= 0.1.3 # req'd by boring
+        - binary-orphans ^>= 1.0.4.1
+        - binary-parser ^>= 0.5.7.5
+        - binary-tagged ^>= 0.3.1
+        - bindings-DSL ^>= 1.0.25
+        - bindings-uname ^>= 0.1
+        - bitarray ^>= 0.0.1.1
+        - blank-canvas ^>= 0.7.4
+        - blaze-svg ^>= 0.3.7
+        - blaze-textual ^>= 0.2.3.1
+        - bloomfilter ^>= 2.0.1.2
+        - boring ^>= 0.2.1
+        - box ^>= 0.9.2.1
+        - box-csv < 0
+        - brick ^>= 2.1.1
+        - broadcast-chan ^>= 0.2.1.2
+        - buffer-builder ^>= 0.2.4.8
+        - byte-order ^>= 0.1.3.0
+        - byteable ^>= 0.1.1
+        - bytehash ^>= 0.1.1.0
+        - bytesmith ^>= 0.3.10.0
+        - bytestring-builder ^>= 0.10.8.2.0
+        - bzlib ^>= 0.5.1.0
+        - ca-province-codes ^>= 1.0.0.0
+        - cabal-install-solver ^>= 3.10.2.1
+        - call-stack ^>= 0.4.0
+        - casing ^>= 0.1.4.1
+        - cassava-megaparsec ^>= 2.0.4
+        - cborg ^>= 0.2.10.0
+        - cereal ^>= 0.5.8.3
+        - cereal-text ^>= 0.1.0.2
+        - cereal-vector ^>= 0.2.0.1
+        - chunked-data ^>= 0.3.1
+        - cipher-aes128 < 0 # 0.7.0.6 compile fail
+        - cipher-blowfish < 0 # 0.0.3 compile fail
+        - cipher-camellia ^>= 0.0.2
+        - cipher-des < 0
+        - classy-prelude ^>= 1.5.0.3
+        - classy-prelude-conduit ^>= 1.5.0
+        - clientsession ^>= 0.9.2.0
+        - cmark-gfm ^>= 0.2.6
+        - colour ^>= 2.3.6
+        - colourista ^>= 0.1.0.2
+        - commutative-semigroups ^>= 0.1.0.1
+        - concurrent-extra ^>= 0.7.0.12
+        - conduit ^>= 1.3.5
+        - config-ini ^>= 0.2.7.0
+        - configurator ^>= 0.3.0.0
+        - constraints-extras ^>= 0.4.0.0
+        - contravariant-extras ^>= 0.3.5.4
+        - control-monad-free ^>= 0.6.2
+        - control-monad-omega ^>= 0.3.2
+        - convertible ^>= 1.1.1.1
+        - cookie ^>= 0.4.6
+        - cpphs ^>= 1.20.9.1
+        - crypt-sha512 ^>= 0
+        - crypto-api ^>= 0.13.3
+        - crypto-api-tests ^>= 0.3
+        - crypto-cipher-tests ^>= 0.0.11
+        - crypto-cipher-types ^>= 0.0.9
+        - crypto-numbers < 0
+        - crypto-pubkey < 0
+        - crypto-pubkey-openssh < 0 # 0.2.7 compile fail
+        - crypto-random < 0 # 0.0.9 compile fail https://github.com/vincenthz/hs-crypto-random/issues/15
+        - cryptohash-cryptoapi ^>= 0.1.4
+        - cryptostore ^>= 0.3.0.1
+        - css-text ^>= 0.1.3.0
+        - csv ^>= 0.1.2
+        - cubicbezier ^>= 0.6.0.7
+        - data-binary-ieee754 ^>= 0.4.4
+        - data-bword ^>= 0.1.0.2
+        - data-checked ^>= 0.3
+        - data-clist ^>= 0.2
+        - data-default ^>= 0.7.1.1
+        - data-default-class ^>= 0.1.2.0
+        - data-default-instances-containers ^>= 0.0.1
+        - data-default-instances-dlist ^>= 0.0.1
+        - data-default-instances-old-locale ^>= 0.0.1
+        - data-dword ^>= 0.3.2.1
+        - data-endian ^>= 0.1.1
+        - data-inttrie ^>= 0.1.4
+        - data-lens-light ^>= 0.1.2.4
+        - data-memocombinators ^>= 0.5.1
+        - data-msgpack-types ^>= 0.0.3
+        - data-serializer ^>= 0.3.5
+        - data-textual ^>= 0.3.0.3
+        - dec ^>= 0.0.5
+        - deepseq-generics ^>= 0.2.0.0
+        - dense-linear-algebra ^>= 0.1.0.0
+        - dictionary-sharing ^>= 0.1.0.0
+        - direct-sqlite ^>= 2.3.28
+        - discount ^>= 0.1.1
+        - distributed-process < 0
+        - distributed-static ^>= 0.3.9
+        - dlist ^>= 1.0
+        - dlist-instances ^>= 0.1.1.1
+        - dlist-nonempty ^>= 0.1.3
+        - double-conversion ^>= 2.0.4.2
+        - dual-tree ^>= 0.2.3.1
+        - easy-file ^>= 0.2.5
+        - easytest < 0
+        - ed25519 ^>= 0.0.5.0
+        - edit-distance ^>= 0.2.2.1
+        - elliptic-curve < 0
+        - elm-bridge ^>= 0.8.2
+        - enclosed-exceptions ^>= 1.0.3
+        - entropy ^>= 0.4.1.10
+        - erf ^>= 2.0.0.0
+        - errorcall-eq-instance ^>= 0.3.0
+        - errors ^>= 2.3.0
+        - expiring-cache-map ^>= 0.0.6.1
+        - extensible ^>= 0.9
+        - extensible-exceptions ^>= 0.1.1.4
+        - fail ^>= 4.9.0.0
+        - fast-logger ^>= 3.2.2
+        - fast-math ^>= 1.0.2
+        - fdo-notify ^>= 0.3.1
+        - fib < 0
+        - file-embed ^>= 0.0.15.0
+        - file-embed-lzma ^>= 0.0.1
+        - filemanip ^>= 0.3.6.3
+        - fin ^>= 0.3
+        - fingertree ^>= 0.1.5.0
+        - fmlist ^>= 0.9.4
+        - formatn ^>= 0.3.0.1
+        - friendly-time ^>= 0.4.1
+        - functor-classes-compat ^>= 2.0.0.2
+        - functor-combinators < 0 # 0.4.1.2 compile fail https://github.com/mstksg/functor-combinators/issues/7
+        - fuzzcheck ^>= 0.1.1
+        - generic-arbitrary ^>= 1.0.1
+        - generically ^>= 0.1.1
+        - generics-sop-lens ^>= 0.2.0.1
+        - ghc-byteorder ^>= 4.11.0.0.10
+        - ghc-compact ^>= 0.1.0.0
+        - ghc-events ^>= 0.19.0.1
+        - ghc-paths ^>= 0.1.0.12
+        - ghc-prof < 0
+        - ghcjs-dom-jsaddle < 0
+        - git-lfs ^>= 1.2.1
+        - gitlib ^>= 3.1.3
+        - gitlib-libgit2 < 0 # 3.1.2.1 compile fail
+        - groom ^>= 0.1.2.1
+        - groups ^>= 0.5.3
+        - gtk ^>= 0.15.8
+        - haha ^>= 0.3.1.1
+        - hamlet ^>= 1.2.0
+        - harp < 0
+        - hashable ^>= 1.4.3.0
+        - haskell-gi-overloading ^>= 1.0
+        - haskell-src-exts ^>= 1.23.1
+        - haskell-src-exts-simple ^>= 1.23.0.0
+        - haskell-tools-builtin-refactorings < 0
+        - haskoin-store-data ^>= 1.2.2
+        - hasql-dynamic-statements ^>= 0.3.1.2
+        - hasql-implicits ^>= 0.1.1
+        - haxl < 0
+        - heap ^>= 1.0.4
+        - here ^>= 1.2.14
+        - hex ^>= 0.2.0
+        - hjsonpointer < 0
+        - hjsonschema < 0
+        - hlibgit2 ^>= 0.18.0.16
+        - hmatrix ^>= 0.20.2
+        - hmatrix-gsl ^>= 0.19.0.1
+        - hmatrix-special ^>= 0.19.0.0
+        - hostname ^>= 1.0
+        - hourglass ^>= 0.2.12
+        - hsc2hs ^>= 0.68.10
+        - hscolour ^>= 1.25
+        - hse-cpp ^>= 0.2
+        - hslogger ^>= 1.3.1.0
+        - hsp < 0 # 0.10.0 ghc-9.6
+        - hspec-attoparsec ^>= 0.1.0.2
+        - hspec-contrib ^>= 0.5.2
+        - hspec-expectations ^>= 0.8.4
+        - hspec-expectations-lifted ^>= 0.10.0
+        - hspec-meta ^>= 2.11.7
+        - hspec-smallcheck ^>= 0.5.3
+        - html ^>= 1.0.1.2
+        - html-entities ^>= 1.1.4.6
+        - http-client-restricted ^>= 0.1.0
+        - http-client-tls ^>= 0.3.6.3
+        - http-date ^>= 0.0.11
+        - http-reverse-proxy ^>= 0.6.0.2
+        - http-types ^>= 0.12.4
+        - httpd-shed ^>= 0.4.1.1
+        - hw-json-simd < 0
+        - hw-string-parse ^>= 0.0.0.5
+        - hxt ^>= 9.3.1.22
+        - hxt-charproperties ^>= 9.5.0.0
+        - hxt-http ^>= 9.1.5.2
+        - hxt-regex-xmlschema ^>= 9.2.0.7
+        - hxt-unicode ^>= 9.0.2.4
+        - iconv ^>= 0.4.1.3
+        - ieee754 ^>= 0.8.0
+        - incremental ^>= 0.3.1
+        - indexed ^>= 0.1.3
+        - infer-license ^>= 0.2.0
+        - insert-ordered-containers ^>= 0.2.5.3
+        - inspection-testing ^>= 0.5.0.2
+        - integer-conversion ^>= 0.1.0.1
+        - integer-logarithms ^>= 1.0.3.1
+        - interpolatedstring-perl6 ^>= 1.0.2
+        - io-streams-haproxy ^>= 1.0.1.0
+        - iproute ^>= 1.7.12
+        - ixset-typed ^>= 0.5.1.0
+        - jsaddle-dom < 0
+        - json ^>= 0.11
+        - json-alt < 0
+        - jsonrpc-tinyclient < 0
+        - kansas-comet ^>= 0.4.2
+        - kleene ^>= 0.1
+        - knob ^>= 0.2.2
+        - language-haskell-extract < 0
+        - largeword ^>= 1.2.5
+        - lattices ^>= 2.2
+        - lazy-csv ^>= 0.5.1
+        - lazysmallcheck ^>= 0.6
+        - leb128-cereal ^>= 1.2
+        - libBF ^>= 0.6.7
+        - libyaml ^>= 0.1.2
+        - lifted-base ^>= 0.2.3.12
+        - loch-th ^>= 0.2.2
+        - lockfree-queue ^>= 0.2.4
+        - log-base ^>= 0.12.0.1
+        - logging-facade ^>= 0.3.1
+        - lrucache ^>= 1.2.0.1
+        - lukko ^>= 0.1.1.3
+        - lz4 ^>= 0.2.3.1
+        - lzma ^>= 0.0.1.0
+        - lzma-clib ^>= 5.2.2
+        - managed ^>= 1.0.10
+        - markov-chain-usage-model ^>= 0.0.0
+        - math-functions ^>= 0.3.4.3
+        - membership ^>= 0.0.1
+        - memcache ^>= 0.3.0.1
+        - memory-hexstring < 0
+        - mersenne-random ^>= 1.0.0.1
+        - mersenne-random-pure64 ^>= 0.2.2.0
+        - mfsolve ^>= 0.3.2.2
+        - microstache ^>= 1.0.2.3
+        - minisat-solver ^>= 0.1
+        - missing-foreign ^>= 0.1.1
+        - mmap ^>= 0.5.9
+        - mmorph ^>= 1.2.0
+        - mockery ^>= 0.3.5
+        - monad-control ^>= 1.0.3.1
+        - monad-extras ^>= 0.6.0
+        - monad-interleave ^>= 0.2.0.1
+        - monad-logger ^>= 0.3.40
+        - monad-loops ^>= 0.4.3
+        - monad-time ^>= 0.4.0.0
+        - monadloc < 0 # 0.7.1 compile fail https://github.com/pepeiborra/monadloc/issues/4
+        - monads-tf ^>= 0.3.0.1
+        - mono-traversable-instances ^>= 0.1.1.0
+        - mono-traversable-keys ^>= 0.3.0
+        - mstate < 0
+        - multimap ^>= 1.2.1
+        - multiset ^>= 0.3.4.3
+        - mwc-random ^>= 0.15.0.2
+        - names-th ^>= 0.3.0.1
+        - nanospec ^>= 0.2.2
+        - nettle ^>= 0.3.0
+        - network ^>= 3.1.4.0
+        - network-bsd ^>= 2.8.1.0
+        - network-byte-order ^>= 0.1.7
+        - network-info ^>= 0.2.1
+        - network-ip ^>= 0.3.0.3
+        - network-multicast ^>= 0.3.2
+        - network-run ^>= 0.2.6
+        - network-transport ^>= 0.5.6
+        - network-uri ^>= 2.6.4.2 && (<2.7.0.0 || >2.7.0.0) # 2.7.0.0 was deprecated, don't remove bound until >2.7.0.0 is released.
+        - next-ref < 0
+        - nicify-lib ^>= 1.0.1
+        - normaldistribution ^>= 1.1.0.3
+        - nothunks ^>= 0.1.5
+        - numhask-prelude < 0
+        - old-locale ^>= 1.0.0.7
+        - old-time ^>= 1.1.0.4
+        - operational ^>= 0.2.4.2
+        - optional-args ^>= 1.0.2
+        - options ^>= 1.2.1.2
+        - optparse-applicative ^>= 0.18.1.0
+        - optparse-simple ^>= 0.1.1.4
+        - parallel ^>= 3.2.2.0
+        - parallel-io ^>= 0.3.5
+        - path-pieces ^>= 0.2.1
+        - pcg-random ^>= 0.1.4.0
+        - peggy < 0
+        - pipes-bytestring ^>= 2.1.7
+        - pipes-group ^>= 1.0.12
+        - placeholders ^>= 0.1
+        - poll ^>= 0.0.0.2
+        - portable-lines ^>= 0.1
+        - posix-pty ^>= 0.2.2
+        - postgresql-libpq ^>= 0.10.0.0
+        - postgresql-simple ^>= 0.7.0.0
+        - postgresql-simple-url ^>= 0.2.1.0
+        - pretty-hex ^>= 1.1
+        - pretty-show ^>= 1.10
+        - prettyprinter-convert-ansi-wl-pprint < 0 # 1.1.2 # fails to compile (#7017)
+        - primes ^>= 0.2.1.0
+        - primitive ^>= 0.8.0.0 && <0.9 # https://github.com/commercialhaskell/stackage/issues/7138
+        - primitive-unaligned ^>= 0.1.1.2
+        - process-extras ^>= 0.7.4
+        - project-template ^>= 0.2.1.0
+        - protobuf ^>= 0.2.1.3 && (<0.2.1.4 || >0.2.1.4) # deprecated version
+        - ptr ^>= 0.16.8.5
+        - pureMD5 ^>= 2.1.4
+        - quickcheck-instances ^>= 0.3.30
+        - quickcheck-io ^>= 0.2.0
+        - quickcheck-simple ^>= 0.1.1.1
+        - quickcheck-unicode ^>= 1.0.1.0
+        - quicklz ^>= 1.5.0.11
+        - ral ^>= 0.2.1 # req'd by boring
+        - random ^>= 1.2.1.1
+        - random-shuffle ^>= 0.0.4
+        - range-set-list ^>= 0.1.3.1
+        - rank1dynamic ^>= 0.4.1
+        - ratio-int ^>= 0.1.2
+        - raw-strings-qq ^>= 1.1
+        - readable ^>= 0.3.1
+        - readline < 0 # 1.0.3.0 setup fail
+        - recv ^>= 0.1.0
+        - refinery < 0 # 0.4.0.0 # fails to compile (#7017)
+        - regex-applicative-text < 0
+        - regex-tdfa-text < 0
+        - relapse ^>= 1.0.0.1
+        - relational-schemas ^>= 0.1.8.1
+        - resource-pool ^>= 0.4.0.0
+        - resourcet ^>= 1.3.0
+        - rest-rewrite ^>= 0.4.2
+        - rfc5051 ^>= 0.2
+        - rio ^>= 0.1.22.0
+        - rio-orphans ^>= 0.1.2.0
+        - row-types ^>= 1.0.1.2
+        - run-haskell-module ^>= 0.0.2
+        - safe-exceptions-checked < 0
+        - safecopy ^>= 0.10.4.2
+        - sandi ^>= 0.5
+        - scale < 0
+        - scientific ^>= 0.3.7.0
+        - securemem ^>= 0.1.10
+        - selective ^>= 0.7
+        - semialign ^>= 1.3
+        - serialise ^>= 0.2.6.1
+        - servant-client-core ^>= 0.20
+        - servant-multipart-client ^>= 0.12.2
+        - servant-swagger-ui ^>= 0.3.5.5.0.0
+        - servant-swagger-ui-core ^>= 0.3.5
+        - servant-swagger-ui-redoc ^>= 0.3.4.1.22.3
+        - servant-yaml < 0
+        - setenv ^>= 0.1.1.3
+        - shakespeare ^>= 2.1.0.1
+        - shakespeare-text ^>= 1.1.0
+        - shell-escape ^>= 0.2.0
+        - simple-reflect ^>= 0.3.3
+        - simple-sendfile ^>= 0.2.32
+        - singleton-bool ^>= 0.1.7
+        - size-based ^>= 0.1.3.2
+        - skein ^>= 1.0.9.4
+        - snap-core ^>= 1.0.5.1
+        - snappy < 0
+        - some ^>= 1.0.6
+        - spdx < 0
+        - special-values ^>= 0.1.0.0
+        - splice ^>= 0.6.1.1
+        - split ^>= 0.2.4
+        - splitmix ^>= 0.1.0.5
+        - sql-words ^>= 0.1.6.5
+        - stateref ^>= 0.3
+        - static-canvas ^>= 0.2.0.3
+        - statistics ^>= 0.16.2.1
+        - step-function ^>= 0.2.0.1
+        - stm-delay ^>= 0.1.1.1
+        - storable-complex ^>= 0.2.3.0
+        - streaming-cassava < 0
+        - streaming-wai ^>= 0.1.1
+        - strict ^>= 0.5
+        - strict-lens ^>= 0.4.0.3
+        - strict-list ^>= 0.1.7.4
+        - string-qq ^>= 0.0.5
+        - string-variants < 0
+        - stringable ^>= 0.1.3
+        - stringbuilder ^>= 0.5.1
+        - structured ^>= 0.1.1
+        - sundown ^>= 0.6
+        - syb ^>= 0.7.2.4
+        - system-fileio ^>= 0.3.16.4
+        - system-filepath ^>= 0.4.14
+        - tabular ^>= 0.2.2.8
+        - tar ^>= 0.5.1.1 && <0.6 # https://github.com/commercialhaskell/stackage/issues/7202
+        - tasty-lua ^>= 1.1.0
+        - tasty-th ^>= 0.1.7
+        - tdigest ^>= 0.3
+        - telegram-bot-api < 0
+        - template ^>= 0.2.0.10
+        - template-haskell-compat-v0208 ^>= 0.1.9.3
+        - temporary ^>= 1.3
+        - temporary-rc ^>= 1.2.0.3
+        - temporary-resourcet ^>= 0.1.0.1
+        - test-framework-hunit ^>= 0.3.0.2
+        - test-framework-quickcheck2 ^>= 0.3.0.5
+        - test-framework-smallcheck ^>= 0.2
+        - test-framework-th < 0
+        - testing-feat ^>= 1.1.1.1
+        - testing-type-modifiers ^>= 0.1.0.1
+        - text-binary ^>= 0.2.1.1
+        - text-iso8601 ^>= 0.1
+        - text-latin1 ^>= 0.3.1
+        - text-postgresql ^>= 0.0.3.1
+        - text-printer ^>= 0.5.0.2
+        - text-short ^>= 0.1.5
+        - text-zipper ^>= 0.13
+        - tf-random ^>= 0.5
+        - th-extras ^>= 0.0.0.7
+        - th-lift-instances ^>= 0.1.20
+        - th-utilities ^>= 0.2.5.0
+        - these ^>= 1.2
+        - these-lens ^>= 1.0.1.3
+        - these-optics ^>= 1.0.1.2
+        - threads ^>= 0.5.1.8
+        - threads-extras ^>= 0.1.0.3
+        - thyme ^>= 0.4
+        - time-locale-compat ^>= 0.1.1.5
+        - time-parsers ^>= 0.2
+        - timeit ^>= 2.0
+        - tls-session-manager ^>= 0.0.4
+        - token-bucket ^>= 0.1.0.1
+        - tonatona < 0
+        - torrent ^>= 10000.1.3
+        - transformers-base ^>= 0.4.6
+        - tree-diff ^>= 0.3.0.1
+        - trivial-constraint ^>= 0.7.0.0
+        - true-name < 0
+        - tuple-th ^>= 0.2.5
+        - type-fun ^>= 0.1.3
+        - type-hint ^>= 0.1
+        - uglymemo ^>= 0.1.0.1
+        - unbounded-delays ^>= 0.1.1.1
+        - unfoldable < 0
+        - unicode-collation ^>= 0.1.3.5
+        - universe ^>= 1.2.2
+        - universe-base ^>= 1.1.3.1
+        - universe-dependent-sum ^>= 1.3
+        - universe-instances-base < 0
+        - universe-instances-extended ^>= 1.1.3
+        - universe-instances-trans < 0
+        - universe-reverse-instances ^>= 1.1.1
+        - universe-some ^>= 1.2.1
+        - unix-time ^>= 0.4.11
+        - url ^>= 2.1.3
+        - utf8-light ^>= 0.4.4.0
+        - utf8-string ^>= 1.0.2
+        - uuid-types ^>= 1.0.5.1
+        - validationt < 0 # 0.3.0 # fails to compile (#7017)
+        - vault ^>= 0.3.1.5
+        - vec ^>= 0.5
+        - vector ^>= 0.13.1.0
+        - vector-algorithms ^>= 0.9.0.1
+        - vector-space ^>= 0.16
+        - vector-th-unbox ^>= 0.2.2
+        - verset ^>= 0.0.1.8
+        - vty ^>= 6.1
+        - vty-crossplatform ^>= 0.4.0.0
+        - vty-unix ^>= 0.2.0.0
+        - wai ^>= 3.2.4
+        - wai-app-static ^>= 3.1.8
+        - wai-conduit ^>= 3.0.0.4
+        - wai-eventsource ^>= 3.0.0
+        - wai-handler-launch ^>= 3.0.3.1
+        - wai-logger ^>= 2.4.0
+        - wai-session ^>= 0.3.3
+        - warp ^>= 3.3.31
+        - wcwidth ^>= 0.0.2
+        - web3-bignum < 0
+        - web3-crypto < 0
+        - web3-ethereum < 0
+        - web3-polkadot < 0
+        - web3-provider < 0
+        - web3-solidity < 0
+        - with-location ^>= 0.1.0
+        - wizards ^>= 1.0.3
+        - word-wrap ^>= 0.5
+        - word8 ^>= 0.1.3
+        - x509 ^>= 1.7.7
+        - x509-store ^>= 1.6.9
+        - x509-system ^>= 1.6.7
+        - x509-validation ^>= 1.6.12
+        - xml ^>= 1.3.14
+        - xml-conduit ^>= 1.9.1.3
+        - xml-conduit-writer < 0 # 0.1.1.4 # fails to compile (#7017)
+        - xml-hamlet ^>= 0.5.0.2
+        - xml-types ^>= 0.3.8
+        - xss-sanitize ^>= 0.3.7.2
+        - yeshql-core ^>= 4.2.0.0
+        - yeshql-hdbc < 0
+        - yesod-core ^>= 1.6.25.1
+        - yesod-form ^>= 1.7.6
+        - yesod-persistent ^>= 1.6.0.8
+        - zlib ^>= 0.6.3.0
+        - zlib-bindings ^>= 0.1.1.5
+
+    # If you stop maintaining a package (either just on stackage, or
+    # completely), you can move it here. It will be disabled if it
+    # starts causing problems.
+    #
+    # See #1056/closed
+    #
+    # When disabling one of these packages, move it to "Removed packages".
+    "Abandoned packages":
+        - cheapskate-highlight < 0
+        - cheapskate-lucid < 0
+        - cmark-lucid ^>= 0.1.0.0
+        - cmark-highlight < 0
+        - Spock-lucid < 0
+        - charsetdetect-ae ^>= 1.1.0.4
+        - text-all < 0
+        - Earley ^>= 0.13.0.1
+        - bower-json < 0
+        - boxes ^>= 0.1.5
+        - charsetdetect-ae ^>= 1.1.0.4 # #6326/closed
+        - coercible-utils < 0 # #6271
+        - compiler-warnings ^>= 0.1.0 # #6326/closed
+        - curl ^>= 1.3.8
+        - docopt < 0 # #6326/closed
+        - dynamic-state ^>= 0.3.1 # #6326/closed
+        - first-class-patterns < 0 # #5965/closed
+        - ghc-trace-events ^>= 0.1.2.7 # #6326/closed
+        - hashing ^>= 0.1.1.0 # #6271
+        - hnix-store-core ^>= 0.7.0.0 # #6271
+        - ilist ^>= 0.4.0.1 # #5965/closed
+        - io-storage ^>= 0.3 # #6326/closed
+        - monadlist ^>= 0.0.2 # #6271
+        - non-empty-sequence ^>= 0.2.0.4
+        - numeric-limits ^>= 0.1.0.0 # #6326/closed
+        - oo-prototypes ^>= 0.1.0.0 # #6326/closed
+        - opentelemetry ^>= 0.8.0 # #6326/closed
+        - opentelemetry-extra ^>= 0.8.0 # #6326/closed
+        - opentelemetry-lightstep ^>= 0.8.0 # #6326/closed
+        - opentelemetry-wai ^>= 0.8.0 # #6326/closed
+        - path ^>= 0.9.5 # #6271
+        - pattern-arrows < 0
+        - planb-token-introspection < 0 # #6326/closed
+        - pointedlist ^>= 0.6.1 # #6326/closed
+        - relude ^>= 1.2.1.0 # #5965/closed
+        - shellmet ^>= 0.0.4.1 # #5965/closed
+        - slist ^>= 0.2.1.0 # #5965/closed
+        - syb-with-class < 0
+        - type-errors-pretty < 0 # #5965/closed
+        - unordered-intmap < 0 # #6326/closed
+        - word-trie ^>= 0.3.0 # #6326/closed
+        - xdg-basedir ^>= 0.2.2 # #6326/closed
+        - yi-rope ^>= 0.11 # #6326/closed
+
+    # Packages without maintainers that cause issues,
+    # this is to prevent us from including them by accident. They can
+    # be removed from this list if they are fixed.
+    "Unmaintained packages with compilation failures": []
+
+     # If you want to make sure a package is removed from stackage,
+     # place it here with a `< 0` constraint and send a pull
+     # request. This will tell us if other packages would be
+     # affected. Packages will be kept in this list indefinitely so
+     # that new packages depending on it will be flagged as well.
+    "Removed packages":
+        - 2captcha < 0 # 0.1.0.0 deprecated
+        - Unique < 0 # 0.4.7.9 removed
+        - cli < 0 # 0.2.0 removed
+        - fingertree-psqueue < 0 # 0.3 compile fail
+        - hastache < 0 # 0.6.1 bounds
+        - heart-core < 0 # 0.3.2 compile fail, deprecated
+        - hnix < 0 # 0.17.0 #6271/closed
+        - json-builder < 0 # 0.3 bounds
+        - lens-labels < 0 # 0.3.0.1 bounds, deprecated #4358/closed
+        - membrain < 0 # 0.0.0.2 bounds #5965/closed
+        - preprocessor-tools < 0 # 2.0.2
+        - present < 0 # 4.1.0 compile fail #6271
+        - prim-array < 0 # 0.2.2 bounds
+        - proto-lens-combinators < 0 # 0.4.0.1 deprecated https://github.com/commercialhaskell/stackage/pull/4358
+        - shortcut-links < 0 # 0.5.1.1 #5965/closed
+        - tinytemplate < 0 # 0.1.2.0 compile fail
+        - tomland < 0 # 1.3.3.2 #5965/closed
+        - type-combinators < 0 # 0.2.4.3 compile fail https://github.com/kylcarte/type-combinators/issues/8
+        - typerep-map < 0 # 0.6.0.0 internal library #5965/closed
+        - universe-instances-base < 0 # 1.1 deprecated
+        - universe-instances-trans < 0 # 1.1 deprecated
+        - validation-selective < 0 # 0.2.0.0 #5965/closed
+        - wai-route < 0 # 1.0.0 compile fail
+        - xxhash < 0 # 0.0.2 compile fail
+
+    # Section for packages that have been mass-disabled due to
+    # compilation failures, e.g. after we upgrade GHC. Every package
+    # should have a `< 0` constraint.
+    #
+    # These constraints can (should?) be moved under the maintainers
+    # name, but please add a "compile fail" comment to them there so
+    # it's clear that they must be built if we want to confirm that
+    # they are working.
+    "Compilation failures":
+        - BiobaseBlast < 0 # 0.3.3.0 compile fail aeson 2.0
+        - Fin < 0 # 0.2.9.0 `@' not in scope
+        - HDBC-mysql < 0 # 0.7.1.0
+        - Taxonomy < 0 # 2.2.0 compile fail aeson 2.0
+        - Workflow < 0 # 0.8.3
+        - accuerr < 0 # 0.2.0.2
+        - aeson-lens < 0 # 0.5.0.0
+        - aeson-with < 0 # 0.1.2.0 compile fail aeson 2.0
+        - auto < 0 # 0.4.3.1
+        - binary-ext < 0 # 2.0.4
+        - bins < 0 # 0.1.2.0
+        - bitcoin-script < 0 # 0.11.1
+        - boolean-like < 0 # 0.1.1.0
+        - cabal-toolkit < 0 # 0.0.7
+        - capataz < 0 # 0.2.1.0
+        - chaselev-deque < 0 # 0.5.0.5
+        - cipher-des < 0 # 0.0.6
+        - coercible-utils < 0 # 0.1.0
+        - composable-associations-aeson < 0 # 0.1.0.1 compile fail aeson 2.0
+        - courier < 0 # 0.1.1.5
+        - crypto-numbers < 0 # 0.2.7
+        - cuckoo-filter < 0 # 0.2.0.2 benchmarks are an exe
+        - data-default-instances-new-base < 0 # 0.0.2
+        - descriptive < 0 # 0.9.5 compile fail aeson 2.0
+        - djinn-ghc < 0 # 0.0.2.3
+        - drinkery < 0 # 0.4
+        - elm-export-persistent < 0 # 1.0.0 compile fail aeson 2.0
+        - etc < 0 # 0.4.1.0 compile fail aeson 2.0
+        - etcd < 0 # 1.0.5
+        - eve < 0 # 0.1.9.0
+        - eventsource-api < 0 # 1.5.1 compile fail aeson 2.0
+        - eventsource-store-specs < 0 # 1.2.1
+        - farmhash < 0 # 0.1.0.5
+        - ftp-client-conduit < 0 # 0.5.0.5
+        - ghcjs-base-stub < 0 # 0.3.0.2 compile fail aeson 2.0
+        - giphy-api < 0 # 0.7.0.0 https://github.com/passy/giphy-api/pull/19
+        - gluturtle < 0 # 0.0.58.1
+        - groundhog < 0 # 0.12.0
+        - haskell-awk < 0 # 1.2.0.1
+        - haskell-import-graph < 0 # 1.0.4
+        - haskell-spacegoo < 0 # 0.2.0.1
+        - hbeanstalk < 0 # 0.2.4
+        - hexstring < 0 # 0.11.1
+        - highjson < 0 # 0.5.0.0 compile fail aeson 2.0
+        - hs-functors < 0 # 0.1.7.1
+        - hschema < 0 # 0.0.1.1
+        - hsebaysdk < 0 # 0.4.1.0 compile fail aeson 2.0
+        - hstatsd < 0 # 0.1
+        - interpolator < 0 # 1.1.0.2
+        - io-choice < 0 # 0.0.7
+        - json-rpc-generic < 0 # 0.2.1.6 compile fail aeson 2.0
+        - katydid < 0 # 0.4.0.2 MonadFail
+        - kawhi < 0 # 0.3.0 compile fail aeson 2.0
+        - lens-typelevel < 0 # 0.1.1.0
+        - llvm-hs < 0 # 9.0.1 llvm-config
+        - llvm-hs-pretty < 0 # 0.9.0.0
+        - machines-binary < 0 # 7.0.0.0
+        - machines-io < 0 # 7.0.0.0
+        - marvin-interpolate < 0 # 1.1.2
+        - mltool < 0 # 0.2.0.1
+        - moesocks < 0 # 1.0.1.0
+        - monad-recorder < 0 # 0.1.1
+        - monad-unlift < 0 # 0.2.0
+        - murmur < 0 # 0.0.0.2
+        - n2o-protocols < 0 # 0.11.2
+        - nri-prelude < 0 # 0.6.0.6 compile fail aeson 2.0
+        - odbc < 0 # 0.2.6 odbc
+        - pdfinfo < 0 # 1.5.4
+        - pencil < 0 # 1.0.1
+        - pipes-aeson < 0 # 0.4.1.8
+        - pipes-network < 0 # 0.6.5
+        - pkcs10 < 0 # 0.2.0.0
+        - planb-token-introspection < 0 # 0.1.4.0
+        - postgresql-orm < 0 # 0.5.1
+        - postgresql-transactional < 0 # 1.1.1
+        - protocol-buffers < 0 # 2.4.17
+        - pushbullet-types < 0 # 0.4.1.0 compile fail aeson 2.0
+        - raaz < 0 # 0.3.8 multiple libraries
+        - record-wrangler < 0 # 0.1.1.0
+        - regex-compat-tdfa < 0 # 0.95.1.4
+        - rescue < 0 # 0.4.2.1
+        - rigel-viz < 0 # 0.2.0.0 compile fail aeson 2.0
+        - rose-trees < 0 # 0.0.4.5 compilation seems to hang?
+        - servant-cli < 0 # 0.1.0.2 compile fail aeson 2.0
+        - servant-github-webhook < 0 # 0.4.2.0 compile fail aeson 2.0
+        - servant-tracing < 0 # 0.2.0.0 compile fail aeson 2.0
+        - sessiontypes < 0 # 0.1.2
+        - simplistic-generics < 0 # 2.0.0
+        - slack-api < 0 # 0.12
+        - snappy < 0 # 0.2.0.2
+        - stm-stats < 0 # 0.2.0.0
+        - sum-type-boilerplate < 0 # 0.1.1
+        - swagger < 0 # 0.3.0 compile fail aeson 2.0
+        - template-toolkit < 0 # 0.1.1.0 compile fail aeson 2.0
+        - text-region < 0 # 0.3.1.0
+        - throttle-io-stream < 0 # 0.2.0.1
+        - throwable-exceptions < 0 # 0.1.0.9
+        - time-qq < 0 # 0.0.1.0
+        - timemap < 0 # 0.0.7 https://github.com/athanclark/timemap/issues/1
+        - tintin < 0 # 1.10.1
+        - tinylog < 0 # 0.15.0
+        - turtle-options < 0 # 0.1.0.4
+        - type-assertions < 0 # 0.1.0.0
+        - uncertain < 0 # 0.3.1.0
+        - unordered-intmap < 0 # 0.1.1
+        - users-persistent < 0 # 0.5.0.2
+        - wai-predicates < 0 # 1.0.0
+        - webex-teams-pipes < 0 # 0.2.0.1
+        - websockets-rpc < 0 # 0.7.0
+        - word24 < 0 # 2.0.1
+        - xls < 0 # 0.1.3 gcc failed
+        - xml-conduit-parse < 0 # 0.3.1.2
+        - xml-to-json < 0 # 2.0.1 compile fail aeson 2.0
+        - xturtle < 0 # 0.2.0.0 xft
+        - yeshql-hdbc < 0 # 4.2.0.0
+
+
+    # See "Large scale enabling/disabling of packages" in CURATORS.md for how to manage this section.
+    #
+    # This section is meant for libraries and executables that have
+    # been disabled due to bounds issues, there is a separate section
+    # for compilation failures as we need to build those packages to
+    # verify if they have been fixeq.
+    "Library and exe bounds failures":
+        - BiobaseENA < 0 # tried BiobaseENA-0.0.0.2, but its *library* requires the disabled package: BiobaseTypes
+        - BiobaseFasta < 0 # tried BiobaseFasta-0.4.0.1, but its *library* requires the disabled package: BiobaseTypes
+        - BiobaseHTTP < 0 # tried BiobaseHTTP-1.2.0, but its *library* requires network < =2.8.0.0 and the snapshot contains network-3.1.4.0
+        - BiobaseHTTP < 0 # tried BiobaseHTTP-1.2.0, but its *library* requires the disabled package: Taxonomy
+        - BiobaseTypes < 0 # tried BiobaseTypes-0.2.1.0, but its *library* requires the disabled package: PrimitiveArray
+        - BiobaseXNA < 0 # tried BiobaseXNA-0.11.1.1, but its *library* requires the disabled package: PrimitiveArray
+        - BlastHTTP < 0 # tried BlastHTTP-1.4.2, but its *library* requires network ==2.8.0.0 and the snapshot contains network-3.1.4.0
+        - BlastHTTP < 0 # tried BlastHTTP-1.4.2, but its *library* requires the disabled package: BiobaseBlast
+        - ConfigFile < 0 # tried ConfigFile-1.1.4, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
+        - EntrezHTTP < 0 # tried EntrezHTTP-1.0.4, but its *library* requires the disabled package: Taxonomy
+        - FPretty < 0 # tried FPretty-1.1, but its *library* requires base >=4.5 && < 4.11 and the snapshot contains base-4.18.1.0
+        - GPipe < 0 # tried GPipe-2.2.5, but its *library* requires hashtables >=1.2 && < 1.3 and the snapshot contains hashtables-1.3.1
+        - GPipe < 0 # tried GPipe-2.2.5, but its *library* requires linear >=1.18 && < 1.21 and the snapshot contains linear-1.22
+        - GPipe < 0 # tried GPipe-2.2.5, but its *library* requires transformers >=0.5.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - Genbank < 0 # tried Genbank-1.0.3, but its *library* requires the disabled package: biocore
+        - HaskellNet-SSL < 0 # tried HaskellNet-SSL-0.3.4.4, but its *library* requires the disabled package: connection
+        - Hoed < 0 # tried Hoed-0.5.1, but its *library* requires the disabled package: regex-tdfa-text
+        - IPv6DB < 0 # tried IPv6DB-0.3.3, but its *executable* requires fast-logger >=2.4.8 && < 3.1 and the snapshot contains fast-logger-3.2.2
+        - IPv6DB < 0 # tried IPv6DB-0.3.3, but its *executable* requires optparse-applicative >=0.12.1.0 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
+        - IPv6DB < 0 # tried IPv6DB-0.3.3, but its *executable* requires wai-logger >=2.2.7 && < 2.4 and the snapshot contains wai-logger-2.4.0
+        - IPv6DB < 0 # tried IPv6DB-0.3.3, but its *library* requires aeson ==2.0.* and the snapshot contains aeson-2.1.2.1
+        - IPv6DB < 0 # tried IPv6DB-0.3.3, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - IPv6DB < 0 # tried IPv6DB-0.3.3, but its *library* requires vector >=0.11.0.0 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - JuicyPixels-blp < 0 # tried JuicyPixels-blp-0.2.0.0, but its *library* requires attoparsec >=0.12 && < 0.14 and the snapshot contains attoparsec-0.14.4
+        - JuicyPixels-blp < 0 # tried JuicyPixels-blp-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - JuicyPixels-blp < 0 # tried JuicyPixels-blp-0.2.0.0, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.3.0
+        - JuicyPixels-blp < 0 # tried JuicyPixels-blp-0.2.0.0, but its *library* requires text-show >=3.7 && < 3.9 and the snapshot contains text-show-3.10.4
+        - JuicyPixels-blp < 0 # tried JuicyPixels-blp-0.2.0.0, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - JuicyPixels-blurhash < 0 # tried JuicyPixels-blurhash-0.1.0.3, but its *executable* requires optparse-applicative >=0.14.3 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - JuicyPixels-blurhash < 0 # tried JuicyPixels-blurhash-0.1.0.3, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - JuicyPixels-blurhash < 0 # tried JuicyPixels-blurhash-0.1.0.3, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - MFlow < 0 # tried MFlow-0.4.6.0, but its *library* requires the disabled package: TCache
+        - MFlow < 0 # tried MFlow-0.4.6.0, but its *library* requires the disabled package: Workflow
+        - MFlow < 0 # tried MFlow-0.4.6.0, but its *library* requires the disabled package: monadloc
+        - MapWith < 0 # tried MapWith-0.2.0.0, but its *library* requires base >=4.9.1 && < 4.15 and the snapshot contains base-4.18.1.0
+        - NanoID < 0 # tried NanoID-3.4.0, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - Network-NineP < 0 # tried Network-NineP-0.4.7.3, but its *library* requires the disabled package: mstate
+        - NoTrace < 0 # tried NoTrace-0.3.0.4, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.18.1.0
+        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires BiobaseFasta ==0.3.0.* and the snapshot contains BiobaseFasta-0.4.0.1
+        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires BiobaseHTTP ==1.1.0 and the snapshot contains BiobaseHTTP-1.2.0
+        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires BiobaseTypes ==0.2.0.* and the snapshot contains BiobaseTypes-0.2.1.0
+        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires aeson < =1.4.2.0 and the snapshot contains aeson-2.1.2.1
+        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires network < =2.8.0.0 and the snapshot contains network-3.1.4.0
+        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: BiobaseBlast
+        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: Taxonomy
+        - Spintax < 0 # tried Spintax-0.3.6, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - Spintax < 0 # tried Spintax-0.3.6, but its *library* requires text >=1.2.2 && < 1.3 and the snapshot contains text-2.0.2
+        - Spock < 0 # tried Spock-0.14.0.0, but its *library* requires the disabled package: Spock-core
+        - Spock-api-server < 0 # tried Spock-api-server-0.14.0.0, but its *library* requires the disabled package: Spock-core
+        - Spock-lucid < 0 # tried Spock-lucid-0.4.0.1, but its *library* requires the disabled package: Spock
+        - Spock-worker < 0 # tried Spock-worker-0.3.1.0, but its *library* requires the disabled package: Spock
+        - Strafunski-StrategyLib < 0 # tried Strafunski-StrategyLib-5.0.1.0, but its *library* requires base >4.4 && < 4.14 and the snapshot contains base-4.18.1.0
+        - TotalMap < 0 # tried TotalMap-0.1.1.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.18.1.0
+        - TotalMap < 0 # tried TotalMap-0.1.1.1, but its *library* requires lens >=4.16 && < 4.20 and the snapshot contains lens-5.2.3
+        - TypeCompose < 0 # tried TypeCompose-0.9.14, but its *library* requires base >=4.9 && < 4.16 and the snapshot contains base-4.18.1.0
+        - accelerate < 0 # tried accelerate-1.3.0.0, but its *library* requires base >=4.12 && < 4.15 and the snapshot contains base-4.18.1.0
+        - accelerate-arithmetic < 0 # tried accelerate-arithmetic-1.0.0.1, but its *library* requires accelerate >=1.0 && < 1.2 and the snapshot contains accelerate-1.3.0.0
+        - accelerate-bignum < 0 # tried accelerate-bignum-0.3.0.0, but its *library* requires the disabled package: accelerate
+        - accelerate-bignum < 0 # tried accelerate-bignum-0.3.0.0, but its *library* requires the disabled package: accelerate-llvm
+        - accelerate-bignum < 0 # tried accelerate-bignum-0.3.0.0, but its *library* requires the disabled package: accelerate-llvm-native
+        - accelerate-bignum < 0 # tried accelerate-bignum-0.3.0.0, but its *library* requires the disabled package: accelerate-llvm-ptx
+        - accelerate-bignum < 0 # tried accelerate-bignum-0.3.0.0, but its *library* requires the disabled package: llvm-hs-pure
+        - accelerate-blas < 0 # tried accelerate-blas-0.3.0.0, but its *library* requires the disabled package: cublas
+        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *executable* requires the disabled package: accelerate-fft
+        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *executable* requires the disabled package: lens-accelerate
+        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *executable* requires the disabled package: linear-accelerate
+        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *executable* requires the disabled package: repa
+        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *executable* requires the disabled package: repa-io
+        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *library* requires the disabled package: accelerate
+        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *library* requires the disabled package: accelerate-llvm-native
+        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *library* requires the disabled package: accelerate-llvm-ptx
+        - accelerate-fft < 0 # tried accelerate-fft-1.3.0.0, but its *library* requires the disabled package: cufft
+        - accelerate-fftw < 0 # tried accelerate-fftw-1.0.0.1, but its *library* requires accelerate >=1.0 && < 1.2 and the snapshot contains accelerate-1.3.0.0
+        - accelerate-fftw < 0 # tried accelerate-fftw-1.0.0.1, but its *library* requires accelerate-io >=1.0 && < 1.1 and the snapshot contains accelerate-io-1.3.0.0
+        - accelerate-fourier < 0 # tried accelerate-fourier-1.0.0.5, but its *library* requires accelerate >=1.0 && < 1.2 and the snapshot contains accelerate-1.3.0.0
+        - accelerate-fourier < 0 # tried accelerate-fourier-1.0.0.5, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.7
+        - accelerate-fourier < 0 # tried accelerate-fourier-1.0.0.5, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - accelerate-io < 0 # tried accelerate-io-1.3.0.0, but its *library* requires the disabled package: accelerate
+        - accelerate-io-bmp < 0 # tried accelerate-io-bmp-0.1.0.0, but its *library* requires the disabled package: accelerate
+        - accelerate-io-bytestring < 0 # tried accelerate-io-bytestring-0.1.0.0, but its *library* requires the disabled package: accelerate
+        - accelerate-io-repa < 0 # tried accelerate-io-repa-0.1.0.0, but its *library* requires the disabled package: accelerate
+        - accelerate-io-repa < 0 # tried accelerate-io-repa-0.1.0.0, but its *library* requires the disabled package: repa
+        - accelerate-io-vector < 0 # tried accelerate-io-vector-0.1.0.0, but its *library* requires the disabled package: accelerate
+        - accelerate-llvm < 0 # tried accelerate-llvm-1.3.0.0, but its *library* requires the disabled package: llvm-hs
+        - accelerate-llvm-native < 0 # tried accelerate-llvm-native-1.3.0.0, but its *library* requires libffi >=0.1 && < 0.2 and the snapshot contains libffi-0.2.1
+        - accelerate-llvm-native < 0 # tried accelerate-llvm-native-1.3.0.0, but its *library* requires the disabled package: llvm-hs
+        - accelerate-llvm-ptx < 0 # tried accelerate-llvm-ptx-1.3.0.0, but its *library* requires the disabled package: llvm-hs
+        - accelerate-utility < 0 # tried accelerate-utility-1.0.0.1, but its *library* requires accelerate >=1.0 && < 1.2 and the snapshot contains accelerate-1.3.0.0
+        - aeson-better-errors < 0 # tried aeson-better-errors-0.9.1.1, but its *library* requires aeson >=0.7 && < 1.6 || >=2.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
+        - aeson-better-errors < 0 # tried aeson-better-errors-0.9.1.1, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
+        - aeson-commit < 0 # tried aeson-commit-1.6.0, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
+        - aeson-default < 0 # tried aeson-default-0.9.1.0, but its *library* requires aeson >=1.2 && < 2 and the snapshot contains aeson-2.1.2.1
+        - aeson-injector < 0 # tried aeson-injector-2.0.0.0, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.18.1.0
+        - aeson-injector < 0 # tried aeson-injector-2.0.0.0, but its *library* requires lens >=4.13 && < 5.2 and the snapshot contains lens-5.2.3
+        - aeson-injector < 0 # tried aeson-injector-2.0.0.0, but its *library* requires servant-docs >=0.7 && < 0.13 and the snapshot contains servant-docs-0.13
+        - airship < 0 # tried airship-0.9.5, but its *library* requires mime-types >=0.1.0 && < 0.1.1 and the snapshot contains mime-types-0.1.2.0
+        - airship < 0 # tried airship-0.9.5, but its *library* requires unix >=2.7 && < 2.8 and the snapshot contains unix-2.8.1.0
+        - al < 0 # tried al-0.1.4.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - alerts < 0 # tried alerts-0.1.2.0, but its *library* requires text >=0.11 && < 2.0 and the snapshot contains text-2.0.2
+        - alg < 0 # tried alg-0.2.13.1, but its *library* requires base >=4.11 && < 4.15 and the snapshot contains base-4.18.1.0
+        - alg < 0 # tried alg-0.2.13.1, but its *library* requires the disabled package: dual
+        - alg < 0 # tried alg-0.2.13.1, but its *library* requires the disabled package: util
+        - animalcase < 0 # tried animalcase-0.1.0.2, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - animalcase < 0 # tried animalcase-0.1.0.2, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - ansigraph < 0 # tried ansigraph-0.3.0.5, but its *library* requires ansi-terminal >=0.6 && < 0.9 and the snapshot contains ansi-terminal-1.0
+        - ansigraph < 0 # tried ansigraph-0.3.0.5, but its *library* requires base >=4.6 && < 4.13 and the snapshot contains base-4.18.1.0
+        - antiope-dynamodb < 0 # tried antiope-dynamodb-7.5.3, but its *library* requires the disabled package: antiope-core
+        - antiope-s3 < 0 # tried antiope-s3-7.5.3, but its *library* requires the disabled package: antiope-core
+        - antiope-s3 < 0 # tried antiope-s3-7.5.3, but its *library* requires the disabled package: antiope-messages
+        - app-settings < 0 # tried app-settings-0.2.0.12, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - arbor-postgres < 0 # tried arbor-postgres-0.0.5, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - arbor-postgres < 0 # tried arbor-postgres-0.0.5, but its *library* requires lens >=4.16 && < 5 and the snapshot contains lens-5.2.3
+        - arbor-postgres < 0 # tried arbor-postgres-0.0.5, but its *library* requires optparse-applicative >=0.14 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
+        - arbor-postgres < 0 # tried arbor-postgres-0.0.5, but its *library* requires postgresql-simple >=0.5 && < 0.7 and the snapshot contains postgresql-simple-0.7.0.0
+        - arbor-postgres < 0 # tried arbor-postgres-0.0.5, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - arbtt < 0 # tried arbtt-0.12.0.3, but its *executable* requires the disabled package: bytestring-progress
+        - arrowp-qq < 0 # tried arrowp-qq-0.3.0, but its *library* requires haskell-src-exts >=1.22.0 && < 1.23 and the snapshot contains haskell-src-exts-1.23.1
+        - arrowp-qq < 0 # tried arrowp-qq-0.3.0, but its *library* requires template-haskell >=2.14.0 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
+        - arrowp-qq < 0 # tried arrowp-qq-0.3.0, but its *library* requires transformers >=0.5.6 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - asciidiagram < 0 # tried asciidiagram-1.3.3.3, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - asciidiagram < 0 # tried asciidiagram-1.3.3.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - async-timer < 0 # tried async-timer-0.2.0.0, but its *library* requires unliftio-core >=0.1.1.0 && < 0.2 and the snapshot contains unliftio-core-0.2.1.0
+        - aur < 0 # tried aur-7.0.7, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
+        - aura < 0 # tried aura-3.2.9, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - aura < 0 # tried aura-3.2.9, but its *library* requires aeson ^>=2.0 and the snapshot contains aeson-2.1.2.1
+        - aura < 0 # tried aura-3.2.9, but its *library* requires algebraic-graphs >=0.1 && < 0.7 and the snapshot contains algebraic-graphs-0.7
+        - aura < 0 # tried aura-3.2.9, but its *library* requires time >=1.8 && < 1.12 and the snapshot contains time-1.12.2
+        - aura < 0 # tried aura-3.2.9, but its *library* requires transformers ^>=0.5 and the snapshot contains transformers-0.6.1.0
+        - aura < 0 # tried aura-3.2.9, but its *library* requires unix ^>=2.7.2.2 and the snapshot contains unix-2.8.1.0
+        - aura < 0 # tried aura-3.2.9, but its *library* requires versions ^>=5 and the snapshot contains versions-6.0.3
+        - avers < 0 # tried avers-0.0.17.1, but its *library* requires MonadRandom >=0.4.2.3 && < 0.6 and the snapshot contains MonadRandom-0.6
+        - avers < 0 # tried avers-0.0.17.1, but its *library* requires aeson >=1.1.2.1 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - avers < 0 # tried avers-0.0.17.1, but its *library* requires attoparsec >=0.13.1.0 && < 0.14 and the snapshot contains attoparsec-0.14.4
+        - avers < 0 # tried avers-0.0.17.1, but its *library* requires base >=4.9.0.0 && < 4.15 and the snapshot contains base-4.18.1.0
+        - avers < 0 # tried avers-0.0.17.1, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - avers < 0 # tried avers-0.0.17.1, but its *library* requires cryptonite >=0.21 && < 0.29 and the snapshot contains cryptonite-0.30
+        - avers < 0 # tried avers-0.0.17.1, but its *library* requires memory >=0.14 && < 0.16 and the snapshot contains memory-0.18.0
+        - avers < 0 # tried avers-0.0.17.1, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - avers < 0 # tried avers-0.0.17.1, but its *library* requires resource-pool >=0.2.3.2 && < 0.3 and the snapshot contains resource-pool-0.4.0.0
+        - avers < 0 # tried avers-0.0.17.1, but its *library* requires template-haskell >=2.11.0.0 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
+        - avers < 0 # tried avers-0.0.17.1, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
+        - avers < 0 # tried avers-0.0.17.1, but its *library* requires time >=1.6.0.1 && < 1.10 and the snapshot contains time-1.12.2
+        - avers < 0 # tried avers-0.0.17.1, but its *library* requires vector >=0.11.0.0 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - avers-api < 0 # tried avers-api-0.1.0, but its *library* requires the disabled package: avers
+        - avers-server < 0 # tried avers-server-0.1.0.1, but its *library* requires the disabled package: avers
+        - avwx < 0 # tried avwx-0.3.0.3, but its *library* requires lens >=4.1 && < 5 and the snapshot contains lens-5.2.3
+        - avwx < 0 # tried avwx-0.3.0.3, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
+        - aws-lambda-haskell-runtime < 0 # tried aws-lambda-haskell-runtime-4.1.2, but its *library* requires the disabled package: safe-exceptions-checked
+        - aws-lambda-haskell-runtime-wai < 0 # tried aws-lambda-haskell-runtime-wai-2.0.2, but its *library* requires the disabled package: aws-lambda-haskell-runtime
+        - axel < 0 # tried axel-0.0.12, but its *library* requires base >=4.12 && < 4.13 and the snapshot contains base-4.18.1.0
+        - axiom < 0 # tried axiom-0.4.7, but its *library* requires the disabled package: transient
+        - b9 < 0 # tried b9-3.2.3, but its *library* requires aeson ==1.4.* and the snapshot contains aeson-2.1.2.1
+        - b9 < 0 # tried b9-3.2.3, but its *library* requires hspec ==2.7.* and the snapshot contains hspec-2.11.7
+        - b9 < 0 # tried b9-3.2.3, but its *library* requires lens ==4.* and the snapshot contains lens-5.2.3
+        - b9 < 0 # tried b9-3.2.3, but its *library* requires text ==1.2.* and the snapshot contains text-2.0.2
+        - base-noprelude < 0 # tried base-noprelude-4.13.0.0, but its *library* requires base ==4.13.0.0 and the snapshot contains base-4.18.1.0
+        - base16-lens < 0 # tried base16-lens-0.1.3.2, but its *library* requires base16 ^>=0.3 and the snapshot contains base16-1.0
+        - base16-lens < 0 # tried base16-lens-0.1.3.2, but its *library* requires bytestring ^>=0.10 and the snapshot contains bytestring-0.11.5.2
+        - base16-lens < 0 # tried base16-lens-0.1.3.2, but its *library* requires lens >=4 && < 5.1 and the snapshot contains lens-5.2.3
+        - base16-lens < 0 # tried base16-lens-0.1.3.2, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
+        - base32-lens < 0 # tried base32-lens-0.1.1.1, but its *library* requires base32 ^>=0.2 and the snapshot contains base32-0.4
+        - base32-lens < 0 # tried base32-lens-0.1.1.1, but its *library* requires bytestring ^>=0.10 and the snapshot contains bytestring-0.11.5.2
+        - base32-lens < 0 # tried base32-lens-0.1.1.1, but its *library* requires lens >=4.0 && < 5.1 and the snapshot contains lens-5.2.3
+        - base32-lens < 0 # tried base32-lens-0.1.1.1, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
+        - base64-lens < 0 # tried base64-lens-0.3.1, but its *library* requires base >=4.14 && < 4.17 and the snapshot contains base-4.18.1.0
+        - base64-lens < 0 # tried base64-lens-0.3.1, but its *library* requires bytestring ^>=0.10 and the snapshot contains bytestring-0.11.5.2
+        - base64-lens < 0 # tried base64-lens-0.3.1, but its *library* requires lens >=4.0 && < 5.1 and the snapshot contains lens-5.2.3
+        - base64-lens < 0 # tried base64-lens-0.3.1, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
+        - beam-migrate < 0 # tried beam-migrate-0.5.2.1, but its *library* requires pqueue >=1.3 && < 1.5 and the snapshot contains pqueue-1.5.0.0
+        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires aeson >=0.11 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires beam-core >=0.8 && < 0.9 and the snapshot contains beam-core-0.10.1.0
+        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires free >=4.12 && < 5.2 and the snapshot contains free-5.2
+        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires hashable >=1.1 && < 1.3 and the snapshot contains hashable-1.4.3.0
+        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires mysql >=0.1 && < 0.2 and the snapshot contains mysql-0.2.1
+        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires time >=1.6 && < 1.10 and the snapshot contains time-1.12.2
+        - beam-postgres < 0 # tried beam-postgres-0.5.3.1, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - beam-postgres < 0 # tried beam-postgres-0.5.3.1, but its *library* requires postgresql-libpq >=0.8 && < 0.10 and the snapshot contains postgresql-libpq-0.10.0.0
+        - beam-postgres < 0 # tried beam-postgres-0.5.3.1, but its *library* requires postgresql-simple >=0.5 && < 0.7 and the snapshot contains postgresql-simple-0.7.0.0
+        - beam-sqlite < 0 # tried beam-sqlite-0.5.3.0, but its *library* requires the disabled package: beam-migrate
+        - bench < 0 # tried bench-1.0.12, but its *executable* requires optparse-applicative >=0.14.0.0 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - bench-show < 0 # tried bench-show-0.3.2, but its *executable* requires base >=4.8 && < 4.17 and the snapshot contains base-4.18.1.0
+        - bench-show < 0 # tried bench-show-0.3.2, but its *executable* requires optparse-applicative >=0.14.2 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - bench-show < 0 # tried bench-show-0.3.2, but its *library* requires ansi-wl-pprint >=0.6 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
+        - bench-show < 0 # tried bench-show-0.3.2, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - bhoogle < 0 # tried bhoogle-0.1.4.2, but its *executable* requires the disabled package: hoogle
+        - binary-bits < 0 # tried binary-bits-0.5, but its *library* requires base >=4 && < 4.13 and the snapshot contains base-4.18.1.0
+        - binary-parsers < 0 # tried binary-parsers-0.2.4.0, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.5.2
+        - bioace < 0 # tried bioace-0.0.1, but its *library* requires the disabled package: biocore
+        - bioalign < 0 # tried bioalign-0.0.5, but its *library* requires the disabled package: biocore
+        - biocore < 0 # tried biocore-0.3.1, but its *library* requires base >=3 && < 4.11 and the snapshot contains base-4.18.1.0
+        - biofasta < 0 # tried biofasta-0.0.3, but its *library* requires the disabled package: biocore
+        - biofastq < 0 # tried biofastq-0.1, but its *library* requires the disabled package: biocore
+        - biopsl < 0 # tried biopsl-0.4, but its *library* requires the disabled package: biocore
+        - bitcoin-api < 0 # tried bitcoin-api-0.12.1, but its *library* requires the disabled package: bitcoin-script
+        - bitcoin-api < 0 # tried bitcoin-api-0.12.1, but its *library* requires the disabled package: hexstring
+        - bitcoin-api-extra < 0 # tried bitcoin-api-extra-0.9.1, but its *library* requires the disabled package: bitcoin-api
+        - bitcoin-api-extra < 0 # tried bitcoin-api-extra-0.9.1, but its *library* requires the disabled package: bitcoin-block
+        - bitcoin-api-extra < 0 # tried bitcoin-api-extra-0.9.1, but its *library* requires the disabled package: bitcoin-tx
+        - bitcoin-block < 0 # tried bitcoin-block-0.13.1, but its *library* requires the disabled package: hexstring
+        - bitcoin-tx < 0 # tried bitcoin-tx-0.13.1, but its *library* requires the disabled package: bitcoin-script
+        - bitcoin-tx < 0 # tried bitcoin-tx-0.13.1, but its *library* requires the disabled package: hexstring
+        - bitcoin-types < 0 # tried bitcoin-types-0.9.2, but its *library* requires the disabled package: hexstring
+        - bits-extra < 0 # tried bits-extra-0.0.2.3, but its *library* requires ghc-prim >=0.5 && < 0.10 and the snapshot contains ghc-prim-0.10.0
+        - blastxml < 0 # tried blastxml-0.3.2, but its *library* requires the disabled package: biocore
+        - bookkeeping < 0 # tried bookkeeping-0.4.0.1, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
+        - boolean-normal-forms < 0 # tried boolean-normal-forms-0.0.1.1, but its *library* requires base >=4.6 && < 4.14 and the snapshot contains base-4.18.1.0
+        - boolean-normal-forms < 0 # tried boolean-normal-forms-0.0.1.1, but its *library* requires cond >=0.4.1 && < 0.5 and the snapshot contains cond-0.5.1
+        - boots < 0 # tried boots-0.2.0.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - both < 0 # tried both-0.1.1.2, but its *library* requires the disabled package: zero
+        - bower-json < 0 # tried bower-json-1.1.0.0, but its *library* requires the disabled package: aeson-better-errors
+        - box-csv < 0 # tried box-csv-0.2.0, but its *library* requires box ^>=0.8 and the snapshot contains box-0.9.2.1
+        - box-csv < 0 # tried box-csv-0.2.0, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
+        - box-csv < 0 # tried box-csv-0.2.0, but its *library* requires time ^>=1.9 and the snapshot contains time-1.12.2
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires aeson ^>=2.0.1 and the snapshot contains aeson-2.1.2.1
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires base ^>=4.15.0 and the snapshot contains base-4.18.1.0
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires bytestring ^>=0.10.12 and the snapshot contains bytestring-0.11.5.2
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc ^>=9.0.1 and the snapshot contains ghc-9.6.3
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc-boot ^>=9.0.1 and the snapshot contains ghc-boot-9.6.3
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc-boot-th ^>=9.0.1 and the snapshot contains ghc-boot-th-9.6.3
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc-exactprint ^>=0.6.4 and the snapshot contains ghc-exactprint-1.7.0.1
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires mtl ^>=2.2.2 and the snapshot contains mtl-2.3.1
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires semigroups ^>=0.19.2 and the snapshot contains semigroups-0.20
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires strict ^>=0.4.0 and the snapshot contains strict-0.5
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires text ^>=1.2.5 and the snapshot contains text-2.0.2
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires transformers ^>=0.5.6 and the snapshot contains transformers-0.6.1.0
+        - buchhaltung < 0 # tried buchhaltung-0.0.7, but its *library* requires the disabled package: regex-tdfa-text
+        - bulletproofs < 0 # tried bulletproofs-1.1.0, but its *library* requires the disabled package: elliptic-curve
+        - bulletproofs < 0 # tried bulletproofs-1.1.0, but its *library* requires the disabled package: galois-field
+        - butcher < 0 # tried butcher-1.3.3.2, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.18.1.0
+        - butcher < 0 # tried butcher-1.3.3.2, but its *library* requires bifunctors < 5.6 and the snapshot contains bifunctors-5.6.1
+        - butcher < 0 # tried butcher-1.3.3.2, but its *library* requires free < 5.2 and the snapshot contains free-5.2
+        - butcher < 0 # tried butcher-1.3.3.2, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
+        - butcher < 0 # tried butcher-1.3.3.2, but its *library* requires transformers < 0.6 and the snapshot contains transformers-0.6.1.0
+        - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires aeson >=1.5.5.1 && < 2.1 and the snapshot contains aeson-2.1.2.1
+        - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires bytestring >=0.10.12.0 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires text >=1.2.4.1 && < 1.3 and the snapshot contains text-2.0.2
+        - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires wuss >=1.1.18 && < 1.2 and the snapshot contains wuss-2.0.1.5
+        - bytestring-progress < 0 # tried bytestring-progress-1.4, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
+        - cabal-flatpak < 0 # tried cabal-flatpak-0.1.0.4, but its *executable* requires optparse-applicative >=0.11 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires aeson >=1.5.6 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires bytestring >=0.10.12.0 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires lens >=4.19.2 && < 5.1 and the snapshot contains lens-5.2.3
+        - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires lens-aeson >=1.1.3 && < 1.2 and the snapshot contains lens-aeson-1.2.3
+        - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires o-clock >=1.2.1 && < 1.3 and the snapshot contains o-clock-1.4.0
+        - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires text >=1.2.4.1 && < 1.3 and the snapshot contains text-2.0.2
+        - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires aeson >=1.5.6 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires bytestring >=0.10.12.0 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires lens >=4.19.2 && < 5.1 and the snapshot contains lens-5.2.3
+        - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires lens-aeson >=1.1.3 && < 1.2 and the snapshot contains lens-aeson-1.2.3
+        - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires o-clock >=1.2.1 && < 1.3 and the snapshot contains o-clock-1.4.0
+        - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires text >=1.2.4.1 && < 1.3 and the snapshot contains text-2.0.2
+        - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires aeson >=1.5.6 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires bytestring >=0.10.12.0 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires lens >=4.19.2 && < 5.1 and the snapshot contains lens-5.2.3
+        - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires o-clock >=1.2.1 && < 1.3 and the snapshot contains o-clock-1.4.0
+        - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires text >=1.2.4.1 && < 1.3 and the snapshot contains text-2.0.2
+        - caster < 0 # tried caster-0.0.3.0, but its *library* requires the disabled package: fast-builder
+        - category < 0 # tried category-0.2.5.0, but its *library* requires base >=4.10 && < 4.15 and the snapshot contains base-4.18.1.0
+        - category < 0 # tried category-0.2.5.0, but its *library* requires the disabled package: dual
+        - category < 0 # tried category-0.2.5.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - cayley-client < 0 # tried cayley-client-0.4.19.2, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - cayley-client < 0 # tried cayley-client-0.4.19.2, but its *library* requires text >=1.2.2 && < 1.3 and the snapshot contains text-2.0.2
+        - cayley-client < 0 # tried cayley-client-0.4.19.2, but its *library* requires transformers >=0.4.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - cereal-time < 0 # tried cereal-time-0.1.0.0, but its *library* requires time >=1.5 && < 1.8.1 and the snapshot contains time-1.12.2
+        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires aeson >=1.0.2.1 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires aeson-casing >=0.1.0.5 && < 0.2 and the snapshot contains aeson-casing-0.2.0.0
+        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires connection >=0.2.7 && < 0.3 and the snapshot contains connection-0.3.1
+        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires http-api-data >=0.3.5 && < 0.3.9 and the snapshot contains http-api-data-0.5.1
+        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires http-client >=0.5.5.0 && < 0.6 and the snapshot contains http-client-0.7.15
+        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires req >=1.0.0 && < 1.3.0 and the snapshot contains req-3.13.1
+        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
+        - cheapskate < 0 # tried cheapskate-0.1.1.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - cheapskate < 0 # tried cheapskate-0.1.1.2, but its *library* requires text >=0.9 && < 1.3 and the snapshot contains text-2.0.2
+        - cheapskate-highlight < 0 # tried cheapskate-highlight-0.1.0.0, but its *library* requires the disabled package: highlighting-kate
+        - cheapskate-lucid < 0 # tried cheapskate-lucid-0.1.0.0, but its *library* requires the disabled package: cheapskate
+        - chiphunk < 0 # tried chiphunk-0.1.4.0, but its *library* requires hashable >=1.2.6.0 && < 1.4 and the snapshot contains hashable-1.4.3.0
+        - clang-compilation-database < 0 # tried clang-compilation-database-0.1.0.1, but its *library* requires base >=4.8 && < 4.12 and the snapshot contains base-4.18.1.0
+        - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* requires base >=4.10 && < 4.13 and the snapshot contains base-4.18.1.0
+        - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* requires template-haskell >=2.12 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
+        - cleff-plugin < 0 # tried cleff-plugin-0.1.0.0, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.18.1.0
+        - cleff-plugin < 0 # tried cleff-plugin-0.1.0.0, but its *library* requires ghc >=8.6 && < 9.3 and the snapshot contains ghc-9.6.3
+        - climb < 0 # tried climb-0.4.1, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
+        - clock-extras < 0 # tried clock-extras-0.1.0.2, but its *library* requires clock >=0.4.6 && < 0.8.0 and the snapshot contains clock-0.8.4
+        - cmark-highlight < 0 # tried cmark-highlight-0.2.0.0, but its *library* requires cmark ==0.5.* and the snapshot contains cmark-0.6.1
+        - cmark-highlight < 0 # tried cmark-highlight-0.2.0.0, but its *library* requires the disabled package: highlighting-kate
+        - codec < 0 # tried codec-0.2.1, but its *library* requires the disabled package: binary-bits
+        - colour-accelerate < 0 # tried colour-accelerate-0.4.0.0, but its *library* requires the disabled package: accelerate
+        - comonad-extras < 0 # tried comonad-extras-4.0.1, but its *library* requires semigroupoids >=4 && < 6 and the snapshot contains semigroupoids-6.0.0.1
+        - comonad-extras < 0 # tried comonad-extras-4.0.1, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - composite-aeson < 0 # tried composite-aeson-0.8.2.2, but its *library* requires aeson >=1.1.2.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
+        - composite-aeson < 0 # tried composite-aeson-0.8.2.2, but its *library* requires mmorph >=1.0.9 && < 1.2 and the snapshot contains mmorph-1.2.0
+        - composite-aeson < 0 # tried composite-aeson-0.8.2.2, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - composite-aeson < 0 # tried composite-aeson-0.8.2.2, but its *library* requires template-haskell >=2.11.1.0 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
+        - composite-aeson < 0 # tried composite-aeson-0.8.2.2, but its *library* requires text >=1.2.2.2 && < 1.3 and the snapshot contains text-2.0.2
+        - composite-aeson < 0 # tried composite-aeson-0.8.2.2, but its *library* requires time >=1.6.0.1 && < 1.12 and the snapshot contains time-1.12.2
+        - composite-aeson < 0 # tried composite-aeson-0.8.2.2, but its *library* requires vector >=0.12.0.1 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - composite-aeson-path < 0 # tried composite-aeson-path-0.8.2.2, but its *library* requires path >=0.6 && < 0.9 and the snapshot contains path-0.9.5
+        - composite-aeson-refined < 0 # tried composite-aeson-refined-0.8.2.2, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - composite-aeson-refined < 0 # tried composite-aeson-refined-0.8.2.2, but its *library* requires refined >=0.1.2.1 && < 0.7 and the snapshot contains refined-0.8.1
+        - composite-aeson-throw < 0 # tried composite-aeson-throw-0.1.0.0, but its *library* requires the disabled package: aeson-better-errors
+        - composite-aeson-throw < 0 # tried composite-aeson-throw-0.1.0.0, but its *library* requires the disabled package: composite-aeson
+        - composite-ekg < 0 # tried composite-ekg-0.8.2.2, but its *library* requires text >=1.2.2.2 && < 1.3 and the snapshot contains text-2.0.2
+        - compressed < 0 # tried compressed-3.11, but its *library* requires containers >=0.3 && < 0.6 and the snapshot contains containers-0.6.7
+        - compressed < 0 # tried compressed-3.11, but its *library* requires hashable >=1.1.2.1 && < 1.3 and the snapshot contains hashable-1.4.3.0
+        - compressed < 0 # tried compressed-3.11, but its *library* requires semigroupoids >=4 && < 6 and the snapshot contains semigroupoids-6.0.0.1
+        - conduit-algorithms < 0 # tried conduit-algorithms-0.0.13.0, but its *library* requires the disabled package: lzma-conduit
+        - conduit-connection < 0 # tried conduit-connection-0.1.0.5, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - conduit-connection < 0 # tried conduit-connection-0.1.0.5, but its *library* requires resourcet >=1.1 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - conduit-connection < 0 # tried conduit-connection-0.1.0.5, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - conduit-throttle < 0 # tried conduit-throttle-0.3.1.0, but its *library* requires the disabled package: throttle-io-stream
+        - confcrypt < 0 # tried confcrypt-0.2.3.3, but its *library* requires amazonka >=1.6 && < 1.7 and the snapshot contains amazonka-2.0
+        - confcrypt < 0 # tried confcrypt-0.2.3.3, but its *library* requires amazonka-kms >=1.6 && < 1.7 and the snapshot contains amazonka-kms-2.0
+        - confcrypt < 0 # tried confcrypt-0.2.3.3, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - confcrypt < 0 # tried confcrypt-0.2.3.3, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - confcrypt < 0 # tried confcrypt-0.2.3.3, but its *library* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
+        - confcrypt < 0 # tried confcrypt-0.2.3.3, but its *library* requires the disabled package: crypto-pubkey-openssh
+        - conferer-hspec < 0 # tried conferer-hspec-1.1.0.0, but its *library* requires hspec-core >=2.0.0 && < 2.8.0 and the snapshot contains hspec-core-2.11.7
+        - conferer-snap < 0 # tried conferer-snap-1.0.0.0, but its *library* requires conferer >=1.0.0.0 && < 1.1.0.0 and the snapshot contains conferer-1.1.0.0
+        - connection < 0 # tried connection-0.3.1, but its *library* requires tls >=1.4 && < 1.7 and the snapshot contains tls-1.8.0
+        - console-style < 0 # tried console-style-0.0.2.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - constraint < 0 # tried constraint-0.1.4.0, but its *library* requires the disabled package: category
+        - construct < 0 # tried construct-0.3.1.1, but its *library* requires rank2classes >=1 && < 1.5 and the snapshot contains rank2classes-1.5.3
+        - containers-unicode-symbols < 0 # tried containers-unicode-symbols-0.3.1.3, but its *library* requires containers >=0.5 && < 0.6.5 and the snapshot contains containers-0.6.7
+        - cprng-aes < 0 # tried cprng-aes-0.6.1, but its *library* requires the disabled package: crypto-random
+        - crypto-pubkey < 0 # tried crypto-pubkey-0.2.8, but its *library* requires the disabled package: crypto-numbers
+        - crypto-pubkey < 0 # tried crypto-pubkey-0.2.8, but its *library* requires the disabled package: crypto-random
+        - cryptocipher < 0 # tried cryptocipher-0.6.2, but its *library* requires the disabled package: cipher-blowfish
+        - cryptocipher < 0 # tried cryptocipher-0.6.2, but its *library* requires the disabled package: cipher-des
+        - csg < 0 # tried csg-0.1.0.6, but its *executable* requires turtle < 1.6 and the snapshot contains turtle-1.6.2
+        - csg < 0 # tried csg-0.1.0.6, but its *library* requires QuickCheck < 2.13 and the snapshot contains QuickCheck-2.14.3
+        - csg < 0 # tried csg-0.1.0.6, but its *library* requires attoparsec < 0.14 and the snapshot contains attoparsec-0.14.4
+        - csg < 0 # tried csg-0.1.0.6, but its *library* requires bytestring < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - csg < 0 # tried csg-0.1.0.6, but its *library* requires simple-vec3 ==0.4.* and the snapshot contains simple-vec3-0.6.0.1
+        - csg < 0 # tried csg-0.1.0.6, but its *library* requires strict < 0.4 and the snapshot contains strict-0.5
+        - csg < 0 # tried csg-0.1.0.6, but its *library* requires transformers < 0.6 and the snapshot contains transformers-0.6.1.0
+        - csv-conduit < 0 # tried csv-conduit-0.7.3.0, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
+        - curl-runnings < 0 # tried curl-runnings-0.17.0, but its *library* requires the disabled package: connection
+        - curl-runnings < 0 # tried curl-runnings-0.17.0, but its *library* requires the disabled package: dhall-json
+        - currencies < 0 # tried currencies-0.2.0.0, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
+        - cusolver < 0 # tried cusolver-0.3.0.0, but its *library* requires the disabled package: cublas
+        - cusolver < 0 # tried cusolver-0.3.0.0, but its *library* requires the disabled package: cusparse
+        - czipwith < 0 # tried czipwith-1.0.1.4, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.18.1.0
+        - czipwith < 0 # tried czipwith-1.0.1.4, but its *library* requires template-haskell >=2.9 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires Cabal >=2.4 && < 3.7 and the snapshot contains Cabal-3.10.1.0
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires attoparsec >=0.13.0.1 && < 0.14 and the snapshot contains attoparsec-0.14.4
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires base >=4.10 && < 4.16 and the snapshot contains base-4.18.1.0
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires bytestring >=0.10.6 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires constraints >=0.11 && < 0.13 and the snapshot contains constraints-0.13.4
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires cryptonite >=0.24 && < 0.30 and the snapshot contains cryptonite-0.30
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires fgl >=5.5.2.3 && < 5.8 and the snapshot contains fgl-5.8.2.0
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires hashable >=1.2.3.3 && < 1.4 and the snapshot contains hashable-1.4.3.0
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires http-types >=0.12.1 && < 0.12.4 and the snapshot contains http-types-0.12.4
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires memory >=0.14 && < 0.17 and the snapshot contains memory-0.18.0
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires regex-tdfa >=1.3.1.0 && < 1.3.2 and the snapshot contains regex-tdfa-1.3.2.2
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires text >=1.2.1.3 && < 1.3 and the snapshot contains text-2.0.2
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires time >=1.5.0.1 && < 1.10 and the snapshot contains time-1.12.2
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires unix >=2.7.1.0 && < 2.8 and the snapshot contains unix-2.8.1.0
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires unix-compat >=0.5 && < 0.6 and the snapshot contains unix-compat-0.7.1
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - data-accessor-template < 0 # tried data-accessor-template-0.2.1.16, but its *library* requires template-haskell >=2.11 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
+        - data-compat < 0 # tried data-compat-0.1.0.4, but its *library* requires base >=4.12.0.0 && < 4.18 and the snapshot contains base-4.18.1.0
+        - data-default-extra < 0 # tried data-default-extra-0.1.0, but its *library* requires the disabled package: data-default-instances-new-base
+        - data-default-instances-text < 0 # tried data-default-instances-text-0.0.1, but its *library* requires text >=0.2 && < 2 and the snapshot contains text-2.0.2
+        - data-tree-print < 0 # tried data-tree-print-0.1.0.2, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.18.1.0
+        - datasets < 0 # tried datasets-0.4.0, but its *library* requires the disabled package: streaming-cassava
+        - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - decidable < 0 # tried decidable-0.3.1.0, but its *library* requires singletons-base < 3.2 and the snapshot contains singletons-base-3.2
+        - deepseq-instances < 0 # tried deepseq-instances-0.1.0.1, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.18.1.0
+        - dhall-json < 0 # tried dhall-json-1.7.12, but its *library* requires optparse-applicative >=0.14.0.0 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - dhall-lsp-server < 0 # tried dhall-lsp-server-1.1.3, but its *library* requires lens >=4.16.1 && < 5.2 and the snapshot contains lens-5.2.3
+        - dhall-lsp-server < 0 # tried dhall-lsp-server-1.1.3, but its *library* requires lsp >=1.2.0.0 && < 1.5 and the snapshot contains lsp-2.3.0.0
+        - dhall-lsp-server < 0 # tried dhall-lsp-server-1.1.3, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - dhall-lsp-server < 0 # tried dhall-lsp-server-1.1.3, but its *library* requires transformers >=0.5.5.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - dhall-nix < 0 # tried dhall-nix-1.1.26, but its *executable* requires optparse-generic >=1.1.1 && < 1.5 and the snapshot contains optparse-generic-1.5.2
+        - dhall-nix < 0 # tried dhall-nix-1.1.26, but its *library* requires the disabled package: hnix
+        - dhall-yaml < 0 # tried dhall-yaml-1.2.12, but its *library* requires optparse-applicative >=0.14.0.0 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires aeson >=1.4.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires base >=4.12.0.0 && < 4.15.0.0 and the snapshot contains base-4.18.1.0
+        - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.0.2
+        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *executable* requires criterion >=0.6.2.1 && < 1.4 and the snapshot contains criterion-1.6.3.0
+        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires attoparsec >=0.10.4.0 && < 0.14 and the snapshot contains attoparsec-0.14.4
+        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires base >=4.8.2 && < 4.11 and the snapshot contains base-4.18.1.0
+        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires bytestring >=0.10.6.0 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires containers >=0.5.6.2 && < 0.6 and the snapshot contains containers-0.6.7
+        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires exceptions >=0.8.3 && < 0.9 and the snapshot contains exceptions-0.10.7
+        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
+        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires time >=1.5.0.1 && < 1.9 and the snapshot contains time-1.12.2
+        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires Cabal >=2.0 && < 2.2 and the snapshot contains Cabal-3.10.1.0
+        - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires the disabled package: cabal-toolkit
+        - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.7
+        - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires hashable >=1.2.0.5 && < 1.3 and the snapshot contains hashable-1.4.3.0
+        - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires random >=1.0 && < 1.2 and the snapshot contains random-1.2.1.1
+        - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires stm >=2.4 && < 2.5 and the snapshot contains stm-2.5.1.0
+        - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
+        - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - distributed-process-monad-control < 0 # tried distributed-process-monad-control-0.5.1.3, but its *library* requires the disabled package: distributed-process
+        - distribution < 0 # tried distribution-1.1.1.0, but its *library* requires containers ==0.5.* and the snapshot contains containers-0.6.7
+        - distribution < 0 # tried distribution-1.1.1.0, but its *library* requires random ==1.1.* and the snapshot contains random-1.2.1.1
+        - docker < 0 # tried docker-0.7.0.1, but its *library* requires text >=1.0.0 && < 2.0.0 and the snapshot contains text-2.0.2
+        - docker < 0 # tried docker-0.7.0.1, but its *library* requires tls >=1.3.7 && < 1.7.0 and the snapshot contains tls-1.8.0
+        - docker-build-cacher < 0 # tried docker-build-cacher-2.1.1, but its *library* requires language-docker >=6.0.4 && < 7.0 and the snapshot contains language-docker-12.1.0
+        - docopt < 0 # tried docopt-0.7.0.7, but its *library* requires containers >=0.6.2 && < 0.6.6 and the snapshot contains containers-0.6.7
+        - earcut < 0 # tried earcut-0.1.0.4, but its *library* requires base >=4.5 && < 4.15 and the snapshot contains base-4.18.1.0
+        - easytest < 0 # tried easytest-0.3, but its *library* requires hedgehog >=0.6 && < =0.6.1 and the snapshot contains hedgehog-1.4
+        - edit < 0 # tried edit-1.0.1.0, but its *library* requires QuickCheck >=2.10 && < 2.13 and the snapshot contains QuickCheck-2.14.3
+        - edit < 0 # tried edit-1.0.1.0, but its *library* requires base >=4.9 && < 4.12 and the snapshot contains base-4.18.1.0
+        - edit < 0 # tried edit-1.0.1.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - effect-handlers < 0 # tried effect-handlers-0.1.0.8, but its *library* requires free >=4.9 && < 5 and the snapshot contains free-5.2
+        - egison < 0 # tried egison-4.1.3, but its *library* requires text >=0.2 && < 1.3 and the snapshot contains text-2.0.2
+        - egison < 0 # tried egison-4.1.3, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - egison < 0 # tried egison-4.1.3, but its *library* requires vector ==0.12.* and the snapshot contains vector-0.13.1.0
+        - egison-pattern-src-th-mode < 0 # tried egison-pattern-src-th-mode-0.2.1.2, but its *library* requires mtl ^>=2.2.1 and the snapshot contains mtl-2.3.1
+        - egison-pattern-src-th-mode < 0 # tried egison-pattern-src-th-mode-0.2.1.2, but its *library* requires template-haskell >=2.2.0 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
+        - egison-pattern-src-th-mode < 0 # tried egison-pattern-src-th-mode-0.2.1.2, but its *library* requires text >=0.1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - ekg < 0 # tried ekg-0.4.0.15, but its *library* requires aeson >=0.4 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - ekg < 0 # tried ekg-0.4.0.15, but its *library* requires base >=4.5 && < 4.15 and the snapshot contains base-4.18.1.0
+        - ekg < 0 # tried ekg-0.4.0.15, but its *library* requires text < 1.3 and the snapshot contains text-2.0.2
+        - ekg < 0 # tried ekg-0.4.0.15, but its *library* requires time < 1.10 and the snapshot contains time-1.12.2
+        - ekg < 0 # tried ekg-0.4.0.15, but its *library* requires transformers < 0.6 and the snapshot contains transformers-0.6.1.0
+        - ekg-json < 0 # tried ekg-json-0.1.0.6, but its *library* requires aeson >=0.4 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - ekg-json < 0 # tried ekg-json-0.1.0.6, but its *library* requires base >=4.5 && < 4.15 and the snapshot contains base-4.18.1.0
+        - ekg-json < 0 # tried ekg-json-0.1.0.6, but its *library* requires text < 1.3 and the snapshot contains text-2.0.2
+        - ekg-statsd < 0 # tried ekg-statsd-0.2.5.0, but its *library* requires base >=4.6 && < 4.15 and the snapshot contains base-4.18.1.0
+        - ekg-statsd < 0 # tried ekg-statsd-0.2.5.0, but its *library* requires text < 1.3 and the snapshot contains text-2.0.2
+        - ekg-statsd < 0 # tried ekg-statsd-0.2.5.0, but its *library* requires time < 1.10 and the snapshot contains time-1.12.2
+        - ekg-wai < 0 # tried ekg-wai-0.1.1.0, but its *library* requires time < 1.10 and the snapshot contains time-1.12.2
+        - elliptic-curve < 0 # tried elliptic-curve-0.3.0, but its *library* requires protolude >=0.2 && < 0.3 and the snapshot contains protolude-0.3.3
+        - emd < 0 # tried emd-0.2.0.0, but its *library* requires the disabled package: conduino
+        - essence-of-live-coding-gloss < 0 # tried essence-of-live-coding-gloss-0.2.7, but its *library* requires the disabled package: essence-of-live-coding
+        - essence-of-live-coding-pulse < 0 # tried essence-of-live-coding-pulse-0.2.7, but its *library* requires the disabled package: essence-of-live-coding
+        - essence-of-live-coding-quickcheck < 0 # tried essence-of-live-coding-quickcheck-0.2.7, but its *library* requires the disabled package: essence-of-live-coding
+        - essence-of-live-coding-warp < 0 # tried essence-of-live-coding-warp-0.2.7, but its *library* requires the disabled package: essence-of-live-coding
+        - euler-tour-tree < 0 # tried euler-tour-tree-0.1.1.0, but its *library* requires the disabled package: Unique
+        - event < 0 # tried event-0.1.4, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.7
+        - event < 0 # tried event-0.1.4, but its *library* requires semigroups >=0.16 && < 0.19 and the snapshot contains semigroups-0.20
+        - event < 0 # tried event-0.1.4, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - eventful-core < 0 # tried eventful-core-0.2.0, but its *library* requires the disabled package: sum-type-boilerplate
+        - eventful-dynamodb < 0 # tried eventful-dynamodb-0.2.0, but its *library* requires the disabled package: eventful-core
+        - eventful-memory < 0 # tried eventful-memory-0.2.0, but its *library* requires the disabled package: eventful-core
+        - eventful-postgresql < 0 # tried eventful-postgresql-0.2.0, but its *library* requires the disabled package: eventful-core
+        - eventful-postgresql < 0 # tried eventful-postgresql-0.2.0, but its *library* requires the disabled package: eventful-sql-common
+        - eventful-sql-common < 0 # tried eventful-sql-common-0.2.0, but its *library* requires persistent-template < 2.7 and the snapshot contains persistent-template-2.12.0.0
+        - eventful-sqlite < 0 # tried eventful-sqlite-0.2.0, but its *library* requires the disabled package: eventful-core
+        - eventful-sqlite < 0 # tried eventful-sqlite-0.2.0, but its *library* requires the disabled package: eventful-sql-common
+        - eventful-test-helpers < 0 # tried eventful-test-helpers-0.2.0, but its *library* requires the disabled package: eventful-core
+        - eventsource-geteventstore-store < 0 # tried eventsource-geteventstore-store-1.2.1, but its *library* requires the disabled package: eventsource-api
+        - eventsource-geteventstore-store < 0 # tried eventsource-geteventstore-store-1.2.1, but its *library* requires the disabled package: eventsource-store-specs
+        - eventsource-geteventstore-store < 0 # tried eventsource-geteventstore-store-1.2.1, but its *library* requires the disabled package: eventstore
+        - eventsource-stub-store < 0 # tried eventsource-stub-store-1.1.1, but its *library* requires the disabled package: eventsource-api
+        - failable < 0 # tried failable-1.2.4.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - failable < 0 # tried failable-1.2.4.0, but its *library* requires transformers >=0.4.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - fast-builder < 0 # tried fast-builder-0.1.3.0, but its *library* requires base >=4.8 && < 4.16 and the snapshot contains base-4.18.1.0
+        - fastmemo < 0 # tried fastmemo-0.1.1, but its *library* requires base >=4.7 && < 4.18 and the snapshot contains base-4.18.1.0
+        - fib < 0 # tried fib-0.1.0.1, but its *library* requires the disabled package: base-noprelude
+        - filecache < 0 # tried filecache-0.4.1, but its *library* requires fsnotify ==0.3.* and the snapshot contains fsnotify-0.4.1.0
+        - filecache < 0 # tried filecache-0.4.1, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - first-class-patterns < 0 # tried first-class-patterns-0.3.2.5, but its *library* requires transformers >=0.1.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - flat-mcmc < 0 # tried flat-mcmc-1.5.2, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
+        - flat-mcmc < 0 # tried flat-mcmc-1.5.2, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - fold-debounce-conduit < 0 # tried fold-debounce-conduit-0.2.0.7, but its *library* requires base >=4.9.0 && < 4.17 and the snapshot contains base-4.18.1.0
+        - fold-debounce-conduit < 0 # tried fold-debounce-conduit-0.2.0.7, but its *library* requires transformers >=0.5.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - foldable1 < 0 # tried foldable1-0.1.0.0, but its *library* requires the disabled package: util
+        - foldable1 < 0 # tried foldable1-0.1.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - fortran-src < 0 # tried fortran-src-0.15.1, but its *library* requires singletons-base >=3.0 && < 3.2 and the snapshot contains singletons-base-3.2
+        - fortran-src < 0 # tried fortran-src-0.15.1, but its *library* requires singletons-th >=3.0 && < 3.2 and the snapshot contains singletons-th-3.2
+        - fortran-src-extras < 0 # tried fortran-src-extras-0.5.0, but its *library* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - freer-simple < 0 # tried freer-simple-1.2.1.2, but its *library* requires template-haskell >=2.11 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
+        - fswatch < 0 # tried fswatch-0.1.0.6, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.18.1.0
+        - fswatch < 0 # tried fswatch-0.1.0.6, but its *library* requires haskeline >=0.7 && < 0.8 and the snapshot contains haskeline-0.8.2.1
+        - ftp-client < 0 # tried ftp-client-0.5.1.4, but its *library* requires the disabled package: connection
+        - functor-products < 0 # tried functor-products-0.1.2.0, but its *library* requires singletons-base < 3.2 and the snapshot contains singletons-base-3.2
+        - functor-products < 0 # tried functor-products-0.1.2.0, but its *library* requires text < 1.3 and the snapshot contains text-2.0.2
+        - galois-field < 0 # tried galois-field-1.0.2, but its *library* requires MonadRandom >=0.5.1 && < 0.6 and the snapshot contains MonadRandom-0.6
+        - galois-field < 0 # tried galois-field-1.0.2, but its *library* requires mod >=0.1.0 && < 0.2 and the snapshot contains mod-0.2.0.1
+        - galois-field < 0 # tried galois-field-1.0.2, but its *library* requires poly >=0.3.2 && < 0.5 and the snapshot contains poly-0.5.1.0
+        - galois-field < 0 # tried galois-field-1.0.2, but its *library* requires protolude >=0.2 && < 0.3 and the snapshot contains protolude-0.3.3
+        - galois-field < 0 # tried galois-field-1.0.2, but its *library* requires vector >=0.12.0 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - gdax < 0 # tried gdax-0.6.0.0, but its *library* requires the disabled package: regex-tdfa-text
+        - generic-aeson < 0 # tried generic-aeson-0.2.0.14, but its *library* requires base >=4.4 && < 4.17 and the snapshot contains base-4.18.1.0
+        - generic-aeson < 0 # tried generic-aeson-0.2.0.14, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* requires base >=4.5 && < 4.14 and the snapshot contains base-4.18.1.0
+        - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* requires generic-deriving >=1.6 && < 1.14 and the snapshot contains generic-deriving-1.14.5
+        - geniplate-mirror < 0 # tried geniplate-mirror-0.7.9, but its *library* requires template-haskell < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires dhall >=1.30.0 && < 1.34 and the snapshot contains dhall-1.42.1
+        - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires ghc >=8.8.2 && < 8.11 and the snapshot contains ghc-9.6.3
+        - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires text >=1.2.3.2 && < 1.3 and the snapshot contains text-2.0.2
+        - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires text-icu >=0.7.0 && < 0.8 and the snapshot contains text-icu-0.8.0.4
+        - ghc-prof < 0 # tried ghc-prof-1.4.1.12, but its *library* requires base >=4.6 && < 4.18 and the snapshot contains base-4.18.1.0
+        - ghc-source-gen < 0 # tried ghc-source-gen-0.4.3.0, but its *library* requires ghc >=8.4 && < 9.3 and the snapshot contains ghc-9.6.3
+        - ghc-syb-utils < 0 # tried ghc-syb-utils-0.3.0.0, but its *library* requires ghc >=7.10 && < 8.6 and the snapshot contains ghc-9.6.3
+        - ghcjs-dom < 0 # tried ghcjs-dom-0.9.5.0, but its *library* requires text >=0.11.0.6 && < 1.3 and the snapshot contains text-2.0.2
+        - ghcjs-dom < 0 # tried ghcjs-dom-0.9.5.0, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - ghcjs-dom-jsaddle < 0 # tried ghcjs-dom-jsaddle-0.9.5.0, but its *library* requires the disabled package: jsaddle-dom
+        - gi-cairo-connector < 0 # tried gi-cairo-connector-0.1.1, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - gi-gsk < 0 # tried gi-gsk-4.0.7, but its *library* requires gi-gdk ==4.0.* and the snapshot contains gi-gdk-3.0.28
+        - github-webhook-handler < 0 # tried github-webhook-handler-0.0.8, but its *library* requires base >=4 && < 4.11 and the snapshot contains base-4.18.1.0
+        - github-webhook-handler-snap < 0 # tried github-webhook-handler-snap-0.0.7, but its *library* requires base >=4 && < 4.11 and the snapshot contains base-4.18.1.0
+        - gitlab-haskell < 0 # tried gitlab-haskell-1.0.0.3, but its *library* requires the disabled package: connection
+        - glaze < 0 # tried glaze-0.3.0.1, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2.3
+        - glazier-react < 0 # tried glazier-react-1.0.0.0, but its *library* requires the disabled package: data-diverse-lens
+        - glazier-react < 0 # tried glazier-react-1.0.0.0, but its *library* requires the disabled package: ghcjs-base-stub
+        - glazier-react < 0 # tried glazier-react-1.0.0.0, but its *library* requires the disabled package: glazier
+        - glazier-react-widget < 0 # tried glazier-react-widget-1.0.0.0, but its *library* requires the disabled package: data-diverse-lens
+        - glazier-react-widget < 0 # tried glazier-react-widget-1.0.0.0, but its *library* requires the disabled package: ghcjs-base-stub
+        - glazier-react-widget < 0 # tried glazier-react-widget-1.0.0.0, but its *library* requires the disabled package: glazier
+        - gloss-accelerate < 0 # tried gloss-accelerate-2.1.0.0, but its *library* requires the disabled package: accelerate
+        - gloss-accelerate < 0 # tried gloss-accelerate-2.1.0.0, but its *library* requires the disabled package: linear-accelerate
+        - gloss-examples < 0 # tried gloss-examples-1.13.0.4, but its *executable* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - gloss-raster < 0 # tried gloss-raster-1.13.1.2, but its *library* requires the disabled package: repa
+        - gloss-raster-accelerate < 0 # tried gloss-raster-accelerate-2.1.0.0, but its *library* requires the disabled package: accelerate
+        - gogol < 0 # tried gogol-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-adexchange-buyer < 0 # tried gogol-adexchange-buyer-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-adexchange-seller < 0 # tried gogol-adexchange-seller-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-admin-datatransfer < 0 # tried gogol-admin-datatransfer-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-admin-directory < 0 # tried gogol-admin-directory-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-admin-emailmigration < 0 # tried gogol-admin-emailmigration-0.3.0, but its *library* requires the disabled package: gogol-core
+        - gogol-admin-reports < 0 # tried gogol-admin-reports-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-adsense < 0 # tried gogol-adsense-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-adsense-host < 0 # tried gogol-adsense-host-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-affiliates < 0 # tried gogol-affiliates-0.3.0, but its *library* requires the disabled package: gogol-core
+        - gogol-analytics < 0 # tried gogol-analytics-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-android-enterprise < 0 # tried gogol-android-enterprise-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-android-publisher < 0 # tried gogol-android-publisher-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-appengine < 0 # tried gogol-appengine-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-apps-activity < 0 # tried gogol-apps-activity-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-apps-calendar < 0 # tried gogol-apps-calendar-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-apps-licensing < 0 # tried gogol-apps-licensing-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-apps-reseller < 0 # tried gogol-apps-reseller-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-apps-tasks < 0 # tried gogol-apps-tasks-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-appstate < 0 # tried gogol-appstate-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-autoscaler < 0 # tried gogol-autoscaler-0.3.0, but its *library* requires the disabled package: gogol-core
+        - gogol-bigquery < 0 # tried gogol-bigquery-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-billing < 0 # tried gogol-billing-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-blogger < 0 # tried gogol-blogger-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-books < 0 # tried gogol-books-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-civicinfo < 0 # tried gogol-civicinfo-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-classroom < 0 # tried gogol-classroom-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-cloudmonitoring < 0 # tried gogol-cloudmonitoring-0.3.0, but its *library* requires the disabled package: gogol-core
+        - gogol-cloudtrace < 0 # tried gogol-cloudtrace-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-compute < 0 # tried gogol-compute-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-container < 0 # tried gogol-container-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-customsearch < 0 # tried gogol-customsearch-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-dataflow < 0 # tried gogol-dataflow-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-dataproc < 0 # tried gogol-dataproc-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-datastore < 0 # tried gogol-datastore-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-debugger < 0 # tried gogol-debugger-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-deploymentmanager < 0 # tried gogol-deploymentmanager-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-dfareporting < 0 # tried gogol-dfareporting-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-discovery < 0 # tried gogol-discovery-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-dns < 0 # tried gogol-dns-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-doubleclick-bids < 0 # tried gogol-doubleclick-bids-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-doubleclick-search < 0 # tried gogol-doubleclick-search-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-drive < 0 # tried gogol-drive-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-firebase-rules < 0 # tried gogol-firebase-rules-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-fitness < 0 # tried gogol-fitness-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-fonts < 0 # tried gogol-fonts-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-freebasesearch < 0 # tried gogol-freebasesearch-0.3.0, but its *library* requires the disabled package: gogol-core
+        - gogol-fusiontables < 0 # tried gogol-fusiontables-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-games < 0 # tried gogol-games-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-games-configuration < 0 # tried gogol-games-configuration-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-games-management < 0 # tried gogol-games-management-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-genomics < 0 # tried gogol-genomics-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-gmail < 0 # tried gogol-gmail-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-groups-migration < 0 # tried gogol-groups-migration-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-groups-settings < 0 # tried gogol-groups-settings-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-identity-toolkit < 0 # tried gogol-identity-toolkit-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-kgsearch < 0 # tried gogol-kgsearch-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-latencytest < 0 # tried gogol-latencytest-0.3.0, but its *library* requires the disabled package: gogol-core
+        - gogol-logging < 0 # tried gogol-logging-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-maps-coordinate < 0 # tried gogol-maps-coordinate-0.3.0, but its *library* requires the disabled package: gogol-core
+        - gogol-maps-engine < 0 # tried gogol-maps-engine-0.3.0, but its *library* requires the disabled package: gogol-core
+        - gogol-mirror < 0 # tried gogol-mirror-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-monitoring < 0 # tried gogol-monitoring-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-oauth2 < 0 # tried gogol-oauth2-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-pagespeed < 0 # tried gogol-pagespeed-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-partners < 0 # tried gogol-partners-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-people < 0 # tried gogol-people-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-play-moviespartner < 0 # tried gogol-play-moviespartner-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-plus < 0 # tried gogol-plus-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-plus-domains < 0 # tried gogol-plus-domains-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-prediction < 0 # tried gogol-prediction-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-proximitybeacon < 0 # tried gogol-proximitybeacon-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-pubsub < 0 # tried gogol-pubsub-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-qpxexpress < 0 # tried gogol-qpxexpress-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-replicapool < 0 # tried gogol-replicapool-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-replicapool-updater < 0 # tried gogol-replicapool-updater-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-resourcemanager < 0 # tried gogol-resourcemanager-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-resourceviews < 0 # tried gogol-resourceviews-0.3.0, but its *library* requires the disabled package: gogol-core
+        - gogol-script < 0 # tried gogol-script-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-sheets < 0 # tried gogol-sheets-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-shopping-content < 0 # tried gogol-shopping-content-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-siteverification < 0 # tried gogol-siteverification-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-spectrum < 0 # tried gogol-spectrum-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-sqladmin < 0 # tried gogol-sqladmin-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-storage < 0 # tried gogol-storage-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-storage-transfer < 0 # tried gogol-storage-transfer-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-tagmanager < 0 # tried gogol-tagmanager-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-taskqueue < 0 # tried gogol-taskqueue-0.3.0, but its *library* requires the disabled package: gogol-core
+        - gogol-translate < 0 # tried gogol-translate-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-urlshortener < 0 # tried gogol-urlshortener-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-useraccounts < 0 # tried gogol-useraccounts-0.3.0, but its *library* requires the disabled package: gogol-core
+        - gogol-vision < 0 # tried gogol-vision-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-webmaster-tools < 0 # tried gogol-webmaster-tools-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-youtube < 0 # tried gogol-youtube-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-youtube-analytics < 0 # tried gogol-youtube-analytics-0.5.0, but its *library* requires the disabled package: gogol-core
+        - gogol-youtube-reporting < 0 # tried gogol-youtube-reporting-0.5.0, but its *library* requires the disabled package: gogol-core
+        - google-cloud < 0 # tried google-cloud-0.0.4, but its *library* requires base >=4.4 && < 4.11 and the snapshot contains base-4.18.1.0
+        - google-oauth2-jwt < 0 # tried google-oauth2-jwt-0.3.3, but its *library* requires base64-bytestring >=1.0.0 && < 1.2.0.1 and the snapshot contains base64-bytestring-1.2.1.0
+        - google-oauth2-jwt < 0 # tried google-oauth2-jwt-0.3.3, but its *library* requires bytestring >=0.10.6 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - google-oauth2-jwt < 0 # tried google-oauth2-jwt-0.3.3, but its *library* requires text >=1.2.2 && < 1.3 and the snapshot contains text-2.0.2
+        - google-translate < 0 # tried google-translate-0.5, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.5.2
+        - google-translate < 0 # tried google-translate-0.5, but its *library* requires http-api-data >=0.2 && < 0.4 and the snapshot contains http-api-data-0.5.1
+        - google-translate < 0 # tried google-translate-0.5, but its *library* requires http-client >=0.4 && < 0.6 and the snapshot contains http-client-0.7.15
+        - google-translate < 0 # tried google-translate-0.5, but its *library* requires text ==1.2.* and the snapshot contains text-2.0.2
+        - google-translate < 0 # tried google-translate-0.5, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - gothic < 0 # tried gothic-0.1.8.1, but its *library* requires vector >=0.12.0.1 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - greskell < 0 # tried greskell-2.0.3.0, but its *library* requires base >=4.9.0.0 && < 4.17 and the snapshot contains base-4.18.1.0
+        - greskell < 0 # tried greskell-2.0.3.0, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
+        - greskell < 0 # tried greskell-2.0.3.0, but its *library* requires transformers >=0.5.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - greskell-core < 0 # tried greskell-core-1.0.0.1, but its *library* requires base >=4.9.0.0 && < 4.17 and the snapshot contains base-4.18.1.0
+        - greskell-core < 0 # tried greskell-core-1.0.0.1, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
+        - greskell-websocket < 0 # tried greskell-websocket-1.0.0.1, but its *library* requires base >=4.9.1.0 && < 4.17 and the snapshot contains base-4.18.1.0
+        - greskell-websocket < 0 # tried greskell-websocket-1.0.0.1, but its *library* requires text >=1.2.2.2 && < 1.3 and the snapshot contains text-2.0.2
+        - groundhog-inspector < 0 # tried groundhog-inspector-0.11.0, but its *library* requires groundhog-th >=0.8 && < 0.12 and the snapshot contains groundhog-th-0.12
+        - groundhog-inspector < 0 # tried groundhog-inspector-0.11.0, but its *library* requires the disabled package: groundhog
+        - groundhog-mysql < 0 # tried groundhog-mysql-0.12, but its *library* requires mysql >=0.1.1.3 && < 0.2 and the snapshot contains mysql-0.2.1
+        - groundhog-mysql < 0 # tried groundhog-mysql-0.12, but its *library* requires the disabled package: groundhog
+        - groundhog-mysql < 0 # tried groundhog-mysql-0.12, but its *library* requires transformers >=0.2.1 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - groundhog-postgresql < 0 # tried groundhog-postgresql-0.12, but its *library* requires postgresql-simple >=0.3 && < 0.7 and the snapshot contains postgresql-simple-0.7.0.0
+        - groundhog-postgresql < 0 # tried groundhog-postgresql-0.12, but its *library* requires the disabled package: groundhog
+        - groundhog-postgresql < 0 # tried groundhog-postgresql-0.12, but its *library* requires transformers >=0.2.1 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - groundhog-postgresql < 0 # tried groundhog-postgresql-0.12, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - groundhog-sqlite < 0 # tried groundhog-sqlite-0.12.0, but its *library* requires the disabled package: groundhog
+        - groundhog-th < 0 # tried groundhog-th-0.12, but its *library* requires aeson >=0.7 && < 2 and the snapshot contains aeson-2.1.2.1
+        - groundhog-th < 0 # tried groundhog-th-0.12, but its *library* requires the disabled package: groundhog
+        - grouped-list < 0 # tried grouped-list-0.2.3.0, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.18.1.0
+        - gtk-sni-tray < 0 # tried gtk-sni-tray-0.1.8.1, but its *library* requires the disabled package: gi-cairo-connector
+        - hOpenPGP < 0 # tried hOpenPGP-2.9.8, but its *library* requires the disabled package: incremental-parser
+        - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires http-client ==0.5.* and the snapshot contains http-client-0.7.15
+        - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires servant >=0.9 && < 0.13 and the snapshot contains servant-0.20.1
+        - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires servant-client >=0.9 && < 0.13 and the snapshot contains servant-client-0.20
+        - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires text ==1.2.* and the snapshot contains text-2.0.2
+        - hadolint < 0 # tried hadolint-2.12.0, but its *library* requires language-docker >=11.0.0 && < 12 and the snapshot contains language-docker-12.1.0
+        - hadoop-streaming < 0 # tried hadoop-streaming-0.2.0.3, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - hadoop-streaming < 0 # tried hadoop-streaming-0.2.0.3, but its *library* requires text >=1.2.2.0 && < 1.3 and the snapshot contains text-2.0.2
+        - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *executable* requires optparse-applicative >=0.11 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
+        - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *library* requires ansi-terminal >=0.9 && < 0.12 and the snapshot contains ansi-terminal-1.0
+        - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *library* requires path >=0.5 && < 0.9 and the snapshot contains path-0.9.5
+        - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *library* requires path-io >=1.2 && < 1.7 and the snapshot contains path-io-1.8.1
+        - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *library* requires time >=1.5 && < 1.11 and the snapshot contains time-1.12.2
+        - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - happstack-hsp < 0 # tried happstack-hsp-7.3.7.7, but its *library* requires the disabled package: hsp
+        - harp < 0 # tried harp-0.4.3.6, but its *library* requires base < 4.18 and the snapshot contains base-4.18.1.0
+        - hasbolt < 0 # tried hasbolt-0.1.6.3, but its *library* requires the disabled package: connection
+        - hashable-time < 0 # tried hashable-time-0.3, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.18.1.0
+        - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires aeson >=0.8.0.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires bytestring >=0.10.4.0 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.1.0
+        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.3
+        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
+        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires the disabled package: references
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.1.0
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.3
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires ghc-boot-th >=8.4 && < 8.7 and the snapshot contains ghc-boot-th-9.6.3
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires the disabled package: references
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.10.1.0
+        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.1.0
+        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.3
+        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
+        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires the disabled package: references
+        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *executable* requires Glob >=0.9 && < 0.10 and the snapshot contains Glob-0.10.2
+        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *executable* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
+        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.1.0
+        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.3
+        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires strict >=0.3 && < 0.4 and the snapshot contains strict-0.5
+        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires the disabled package: references
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.10.1.0
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires Diff >=0.3 && < 0.4 and the snapshot contains Diff-0.4.1
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.18.1.0
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.3
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires network >=2.6 && < 2.9 and the snapshot contains network-3.1.4.0
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires strict >=0.3 && < 0.4 and the snapshot contains strict-0.5
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires the disabled package: references
+        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.1.0
+        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires criterion >=1.1 && < 1.6 and the snapshot contains criterion-1.6.3.0
+        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.3
+        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
+        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires the disabled package: references
+        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.1.0
+        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.3
+        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires the disabled package: references
+        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires warp >=3.2 && < 3.3 and the snapshot contains warp-3.3.31
+        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.1.0
+        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.3
+        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires the disabled package: references
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.10.1.0
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.1.0
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.3
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires the disabled package: references
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.1.0
+        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.3
+        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires the disabled package: references
+        - haskey < 0 # tried haskey-0.3.1.0, but its *library* requires stm-containers >=0.2 && < 1 || >=1.1 && < 1.2 and the snapshot contains stm-containers-1.2.0.3
+        - haskey-btree < 0 # tried haskey-btree-0.3.0.1, but its *library* requires text >=1.2.1 && < 2 and the snapshot contains text-2.0.2
+        - haskey-mtl < 0 # tried haskey-mtl-0.3.1.0, but its *library* requires monad-control >=1.0.1.0 && < 1.0.2.4 and the snapshot contains monad-control-1.0.3.1
+        - haskoin-store < 0 # tried haskoin-store-1.2.3, but its *library* requires the disabled package: statsd-rupp
+        - hasmin < 0 # tried hasmin-1.0.3, but its *executable* requires bytestring >=0.10.2.0 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - hasmin < 0 # tried hasmin-1.0.3, but its *executable* requires optparse-applicative >=0.11 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
+        - hasmin < 0 # tried hasmin-1.0.3, but its *library* requires attoparsec >=0.12 && < 0.14 and the snapshot contains attoparsec-0.14.4
+        - hasmin < 0 # tried hasmin-1.0.3, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - hasmin < 0 # tried hasmin-1.0.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - hasql-queue < 0 # tried hasql-queue-1.2.0.2, but its *executable* requires the disabled package: tmp-postgres
+        - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires aeson >=0.6 && < 2.1 and the snapshot contains aeson-2.1.2.1
+        - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.3.0
+        - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires text >=1.2.1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires time >=1.4 && < 1.10 and the snapshot contains time-1.12.2
+        - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - haxl-amazonka < 0 # tried haxl-amazonka-0.1.1, but its *library* requires the disabled package: haxl
+        - hedgehog-fakedata < 0 # tried hedgehog-fakedata-0.0.1.5, but its *library* requires hedgehog >=0.1 && < 1.3 and the snapshot contains hedgehog-1.4
+        - hedgehog-optics < 0 # tried hedgehog-optics-1.0.0.3, but its *library* requires hedgehog ^>=1.1.2 || ^>=1.2 and the snapshot contains hedgehog-1.4
+        - herms < 0 # tried herms-1.9.0.4, but its *executable* requires ansi-terminal >=0.7.0 && < =0.8.1 and the snapshot contains ansi-terminal-1.0
+        - herms < 0 # tried herms-1.9.0.4, but its *executable* requires brick >=0.19 && < =0.39 and the snapshot contains brick-2.1.1
+        - herms < 0 # tried herms-1.9.0.4, but its *executable* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - herms < 0 # tried herms-1.9.0.4, but its *executable* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
+        - herms < 0 # tried herms-1.9.0.4, but its *executable* requires semigroups >=0.18.3 && < 0.19 and the snapshot contains semigroups-0.20
+        - herms < 0 # tried herms-1.9.0.4, but its *executable* requires vty >=5.15 && < =5.23 and the snapshot contains vty-6.1
+        - hgeometry < 0 # tried hgeometry-0.14, but its *library* requires the disabled package: vector-circular
+        - hgeometry-combinatorial < 0 # tried hgeometry-combinatorial-0.14, but its *library* requires the disabled package: vector-circular
+        - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires aeson >=0.8 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.1.0
+        - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires template-haskell >=2.10 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
+        - hid < 0 # tried hid-0.2.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - hid < 0 # tried hid-0.2.2, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - hidden-char < 0 # tried hidden-char-0.1.0.2, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.18.1.0
+        - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* requires base >=4.7 && < 4.12 and the snapshot contains base-4.18.1.0
+        - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* requires mmorph >=1.0 && < 1.2 and the snapshot contains mmorph-1.2.0
+        - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* requires transformers-compat >=0.3 && < 0.7 and the snapshot contains transformers-compat-0.7.2
+        - higher-leveldb < 0 # tried higher-leveldb-0.6.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - higher-leveldb < 0 # tried higher-leveldb-0.6.0.0, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
+        - higher-leveldb < 0 # tried higher-leveldb-0.6.0.0, but its *library* requires resourcet >=1.2.3 && < =1.3 and the snapshot contains resourcet-1.3.0
+        - higher-leveldb < 0 # tried higher-leveldb-0.6.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - highjson-swagger < 0 # tried highjson-swagger-0.5.0.0, but its *library* requires the disabled package: highjson
+        - highjson-th < 0 # tried highjson-th-0.5.0.0, but its *library* requires the disabled package: highjson
+        - hip < 0 # tried hip-1.5.6.0, but its *library* requires the disabled package: repa
+        - hit < 0 # tried hit-0.7.0, but its *executable* requires the disabled package: git
+        - hjsonpointer < 0 # tried hjsonpointer-1.5.0, but its *library* requires aeson >=0.7 && < 1.4 and the snapshot contains aeson-2.1.2.1
+        - hjsonpointer < 0 # tried hjsonpointer-1.5.0, but its *library* requires hashable ==1.2.* and the snapshot contains hashable-1.4.3.0
+        - hjsonpointer < 0 # tried hjsonpointer-1.5.0, but its *library* requires text ==1.2.* and the snapshot contains text-2.0.2
+        - hjsonpointer < 0 # tried hjsonpointer-1.5.0, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires QuickCheck >=2.8 && < 2.11 and the snapshot contains QuickCheck-2.14.3
+        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires aeson >=0.11 && < 1.4 and the snapshot contains aeson-2.1.2.1
+        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.5.2
+        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires containers ==0.5.* and the snapshot contains containers-0.6.7
+        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires hashable ==1.2.* and the snapshot contains hashable-1.4.3.0
+        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires hjsonpointer >=1.1 && < 1.4 and the snapshot contains hjsonpointer-1.5.0
+        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires http-client >=0.4.30 && < 0.6 and the snapshot contains http-client-0.7.15
+        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires http-types >=0.8 && < 0.10 and the snapshot contains http-types-0.12.4
+        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires profunctors >=5.0 && < 5.3 and the snapshot contains profunctors-5.6.2
+        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires protolude >=0.1.10 && < 0.3 and the snapshot contains protolude-0.3.3
+        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
+        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - hledger-ui < 0 # tried hledger-ui-1.32.1, but its *library* requires brick >=1.5 && < 2 and the snapshot contains brick-2.1.1
+        - hledger-ui < 0 # tried hledger-ui-1.32.1, but its *library* requires vty >=5.15 && < 6 and the snapshot contains vty-6.1
+        - hmatrix-repa < 0 # tried hmatrix-repa-0.1.2.2, but its *library* requires the disabled package: repa
+        - hnock < 0 # tried hnock-0.4.0, but its *library* requires text >=1.2.3.0 && < 1.3 and the snapshot contains text-2.0.2
+        - hocilib < 0 # tried hocilib-0.2.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - hocon < 0 # tried hocon-0.1.0.4, but its *library* requires MissingH < =1.4.3.0 and the snapshot contains MissingH-1.6.0.1
+        - hocon < 0 # tried hocon-0.1.0.4, but its *library* requires parsec < =3.1.14.0 and the snapshot contains parsec-3.1.16.1
+        - hocon < 0 # tried hocon-0.1.0.4, but its *library* requires split < =0.2.3.4 and the snapshot contains split-0.2.4
+        - holy-project < 0 # tried holy-project-0.2.0.1, but its *library* requires the disabled package: hastache
+        - hoogle < 0 # tried hoogle-5.0.18.3, but its *library* requires the disabled package: connection
+        - hopenpgp-tools < 0 # tried hopenpgp-tools-0.23.8, but its *executable* requires the disabled package: hOpenPGP
+        - hpack-dhall < 0 # tried hpack-dhall-0.5.7, but its *library* requires hpack ==0.35.* and the snapshot contains hpack-0.36.0
+        - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires aeson >=0.7.1 && < 1.3 and the snapshot contains aeson-2.1.2.1
+        - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.7
+        - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires retry >=0.5 && < 0.8 and the snapshot contains retry-0.9.3.1
+        - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires transformers >=0.4.1 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - hpio < 0 # tried hpio-0.9.0.7, but its *executable* requires optparse-applicative >=0.11.0 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
+        - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires QuickCheck >=2.7.6 && < 2.13 and the snapshot contains QuickCheck-2.14.3
+        - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires bytestring >=0.10.4 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires mtl >=2.1.3 && < 2.3 and the snapshot contains mtl-2.3.1
+        - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires protolude ==0.2.* and the snapshot contains protolude-0.3.3
+        - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires text >=1.2.0 && < 1.3 and the snapshot contains text-2.0.2
+        - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires transformers >=0.3.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires unix >=2.7.0 && < 2.8 and the snapshot contains unix-2.8.1.0
+        - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires unix-bytestring >=0.3.7 && < 0.4 and the snapshot contains unix-bytestring-0.4.0
+        - hprotoc < 0 # tried hprotoc-2.4.17, but its *library* requires the disabled package: protocol-buffers
+        - hquantlib < 0 # tried hquantlib-0.0.5.1, but its *library* requires statistics >=0.15.0.0 && < 0.16.0.0 and the snapshot contains statistics-0.16.2.1
+        - hquantlib < 0 # tried hquantlib-0.0.5.1, but its *library* requires time >=1.9.0.0 && < 1.10.0.0 and the snapshot contains time-1.12.2
+        - hquantlib < 0 # tried hquantlib-0.0.5.1, but its *library* requires vector >=0.11.0.0 && < 0.13.0.0 and the snapshot contains vector-0.13.1.0
+        - hquantlib < 0 # tried hquantlib-0.0.5.1, but its *library* requires vector-algorithms >=0.8.0.0 && < 0.9.0.0 and the snapshot contains vector-algorithms-0.9.0.1
+        - hquantlib-time < 0 # tried hquantlib-time-0.0.5.2, but its *library* requires time >=1.4.0.0 && < 1.12.0.0 and the snapshot contains time-1.12.2
+        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires Cabal >=1.24.0.0 && < 3.7 and the snapshot contains Cabal-3.10.1.0
+        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires base >=4.9.0.0 && < 4.16 and the snapshot contains base-4.18.1.0
+        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires ghc >=8.0.2 && < 9.1 and the snapshot contains ghc-9.6.3
+        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires strict >=0.3.2 && < 0.5 and the snapshot contains strict-0.5
+        - hsb2hs < 0 # tried hsb2hs-0.3.1, but its *executable* requires the disabled package: preprocessor-tools
+        - hschema-aeson < 0 # tried hschema-aeson-0.0.1.1, but its *library* requires the disabled package: hschema
+        - hschema-prettyprinter < 0 # tried hschema-prettyprinter-0.0.1.1, but its *library* requires the disabled package: hschema
+        - hschema-quickcheck < 0 # tried hschema-quickcheck-0.0.1.1, but its *library* requires the disabled package: hschema
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires aeson >=1.2.4.0 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires attoparsec >=0.13.1.0 && < 0.14 and the snapshot contains attoparsec-0.14.4
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires fsnotify >=0.2.1 && < 0.4 and the snapshot contains fsnotify-0.4.1.0
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires ghc-boot >=8.0.1 && < 8.11 and the snapshot contains ghc-boot-9.6.3
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires ghc-lib-parser ==8.10.* and the snapshot contains ghc-lib-parser-9.6.3.20231121
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires hlint >=3.0.0 && < 3.3.0 and the snapshot contains hlint-3.6.1
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires http-client >=0.5 && < 0.7 and the snapshot contains http-client-0.7.15
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires lens >=4.14 && < 4.20 and the snapshot contains lens-5.2.3
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires mmorph >=1.0.9 && < 1.2 and the snapshot contains mmorph-1.2.0
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires optparse-applicative >=0.12.1.0 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires template-haskell >=2.11.0 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires text >=1.2.2.2 && < 1.3 and the snapshot contains text-2.0.2
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires the disabled package: text-region
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires time >=1.6.0.1 && < 1.10 and the snapshot contains time-1.12.2
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires unix >=2.7.2.0 && < 2.8 and the snapshot contains unix-2.8.1.0
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires vector >=0.11.0.0 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - hspec-need-env < 0 # tried hspec-need-env-0.1.0.10, but its *library* requires base >=4.6.0.0 && < 4.17 and the snapshot contains base-4.18.1.0
+        - hspec-need-env < 0 # tried hspec-need-env-0.1.0.10, but its *library* requires hspec-core >=2.2.4 && < 2.11 and the snapshot contains hspec-core-2.11.7
+        - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.18.1.0
+        - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* requires hspec-core ==2.7.* and the snapshot contains hspec-core-2.11.7
+        - hsx-jmacro < 0 # tried hsx-jmacro-7.3.8.2, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
+        - hsx-jmacro < 0 # tried hsx-jmacro-7.3.8.2, but its *library* requires the disabled package: hsp
+        - hsx2hs < 0 # tried hsx2hs-0.14.1.11, but its *library* requires template-haskell >=2.7 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - hsyslog-udp < 0 # tried hsyslog-udp-0.2.5, but its *library* requires bytestring < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - hsyslog-udp < 0 # tried hsyslog-udp-0.2.5, but its *library* requires text < 1.3 and the snapshot contains text-2.0.2
+        - hsyslog-udp < 0 # tried hsyslog-udp-0.2.5, but its *library* requires time < 1.10 and the snapshot contains time-1.12.2
+        - hsyslog-udp < 0 # tried hsyslog-udp-0.2.5, but its *library* requires unix < 2.8 and the snapshot contains unix-2.8.1.0
+        - htoml < 0 # tried htoml-1.0.0.3, but its *library* requires aeson >=0.8 && < 2 and the snapshot contains aeson-2.1.2.1
+        - htoml < 0 # tried htoml-1.0.0.3, but its *library* requires text >=1.0 && < 2 and the snapshot contains text-2.0.2
+        - hw-balancedparens < 0 # tried hw-balancedparens-0.4.1.3, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-eliasfano < 0 # tried hw-eliasfano-0.1.2.1, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-eliasfano < 0 # tried hw-eliasfano-0.1.2.1, but its *executable* requires resourcet >=1.2.2 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - hw-excess < 0 # tried hw-excess-0.2.3.0, but its *library* requires the disabled package: hw-rankselect-base
+        - hw-hedgehog < 0 # tried hw-hedgehog-0.1.1.1, but its *library* requires hedgehog >=0.6 && < 1.3 and the snapshot contains hedgehog-1.4
+        - hw-ip < 0 # tried hw-ip-2.4.2.1, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-json < 0 # tried hw-json-1.3.2.4, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-json < 0 # tried hw-json-1.3.2.4, but its *library* requires aeson >=2.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
+        - hw-json < 0 # tried hw-json-1.3.2.4, but its *library* requires ansi-wl-pprint >=0.6.8.2 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
+        - hw-json-simd < 0 # tried hw-json-simd-0.1.1.2, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-json-simple-cursor < 0 # tried hw-json-simple-cursor-0.1.1.1, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-json-standard-cursor < 0 # tried hw-json-standard-cursor-0.2.3.2, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-mquery < 0 # tried hw-mquery-0.2.1.1, but its *library* requires ansi-wl-pprint >=0.6.8 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
+        - hw-packed-vector < 0 # tried hw-packed-vector-0.2.1.1, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-rankselect < 0 # tried hw-rankselect-0.13.4.1, but its *executable* requires optparse-applicative >=0.11 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-rankselect-base < 0 # tried hw-rankselect-base-0.3.4.1, but its *library* requires the disabled package: bits-extra
+        - hw-simd < 0 # tried hw-simd-0.1.2.2, but its *library* requires the disabled package: bits-extra
+        - hw-simd < 0 # tried hw-simd-0.1.2.2, but its *library* requires the disabled package: hw-rankselect
+        - hw-succinct < 0 # tried hw-succinct-0.1.0.1, but its *library* requires the disabled package: hw-balancedparens
+        - hw-succinct < 0 # tried hw-succinct-0.1.0.1, but its *library* requires the disabled package: hw-rankselect
+        - hw-xml < 0 # tried hw-xml-0.5.1.1, but its *executable* requires optparse-applicative >=0.15.1.0 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-xml < 0 # tried hw-xml-0.5.1.1, but its *library* requires ansi-wl-pprint >=0.6.9 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
+        - hw-xml < 0 # tried hw-xml-0.5.1.1, but its *library* requires ghc-prim >=0.5 && < 0.10 and the snapshot contains ghc-prim-0.10.0
+        - hw-xml < 0 # tried hw-xml-0.5.1.1, but its *library* requires resourcet >=1.2.2 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - hw-xml < 0 # tried hw-xml-0.5.1.1, but its *library* requires text >=1.2.3.2 && < 2 and the snapshot contains text-2.0.2
+        - idris < 0 # tried idris-1.3.4, but its *library* requires Cabal >=2.4 && < =3.4 and the snapshot contains Cabal-3.10.1.0
+        - idris < 0 # tried idris-1.3.4, but its *library* requires aeson >=0.6 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - idris < 0 # tried idris-1.3.4, but its *library* requires ansi-terminal < 0.12 and the snapshot contains ansi-terminal-1.0
+        - idris < 0 # tried idris-1.3.4, but its *library* requires ansi-wl-pprint < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
+        - idris < 0 # tried idris-1.3.4, but its *library* requires bytestring < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - idris < 0 # tried idris-1.3.4, but its *library* requires fsnotify >=0.2 && < 0.4 and the snapshot contains fsnotify-0.4.1.0
+        - idris < 0 # tried idris-1.3.4, but its *library* requires libffi < 0.2 and the snapshot contains libffi-0.2.1
+        - idris < 0 # tried idris-1.3.4, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - idris < 0 # tried idris-1.3.4, but its *library* requires network >=2.7 && < 3.1.2 and the snapshot contains network-3.1.4.0
+        - idris < 0 # tried idris-1.3.4, but its *library* requires optparse-applicative >=0.13 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
+        - idris < 0 # tried idris-1.3.4, but its *library* requires text >=1.2.1.0 && < 1.4 and the snapshot contains text-2.0.2
+        - idris < 0 # tried idris-1.3.4, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - idris < 0 # tried idris-1.3.4, but its *library* requires unix < 2.8 and the snapshot contains unix-2.8.1.0
+        - idris < 0 # tried idris-1.3.4, but its *library* requires vector < 0.13 and the snapshot contains vector-0.13.1.0
+        - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: haskell-names
+        - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: log-warper
+        - incremental-parser < 0 # tried incremental-parser-0.5.0.5, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - indentation-core < 0 # tried indentation-core-0.0.0.2, but its *library* requires base >=4.6 && < 4.13 and the snapshot contains base-4.18.1.0
+        - indentation-parsec < 0 # tried indentation-parsec-0.0.0.2, but its *library* requires base >=4.6 && < 4.13 and the snapshot contains base-4.18.1.0
+        - inline-java < 0 # tried inline-java-0.10.0, but its *library* requires ghc >=8.10.1 && < =8.11 and the snapshot contains ghc-9.6.3
+        - inline-java < 0 # tried inline-java-0.10.0, but its *library* requires the disabled package: jni
+        - inliterate < 0 # tried inliterate-0.1.0, but its *library* requires the disabled package: cheapskate
+        - instance-control < 0 # tried instance-control-0.1.2.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - instance-control < 0 # tried instance-control-0.1.2.0, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - interpolatedstring-qq2 < 0 # tried interpolatedstring-qq2-0.1.0.0, but its *library* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - interpolatedstring-qq2 < 0 # tried interpolatedstring-qq2-0.1.0.0, but its *library* requires template-haskell >=2.14.0.0 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
+        - interpolatedstring-qq2 < 0 # tried interpolatedstring-qq2-0.1.0.0, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
+        - intro < 0 # tried intro-0.9.0.0, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - intro < 0 # tried intro-0.9.0.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - intro < 0 # tried intro-0.9.0.0, but its *library* requires text >=0.7 && < 1.3 and the snapshot contains text-2.0.2
+        - intro < 0 # tried intro-0.9.0.0, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - ipa < 0 # tried ipa-0.3.1.1, but its *library* requires template-haskell >=2.14 && < 2.18 and the snapshot contains template-haskell-2.20.0.0
+        - ipa < 0 # tried ipa-0.3.1.1, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
+        - ipa < 0 # tried ipa-0.3.1.1, but its *library* requires unicode-transforms ^>=0.3.7 and the snapshot contains unicode-transforms-0.4.0.1
+        - irc-client < 0 # tried irc-client-1.1.2.3, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - irc-client < 0 # tried irc-client-1.1.2.3, but its *library* requires network-conduit-tls >=1.1 && < 1.4 and the snapshot contains network-conduit-tls-1.4.0
+        - irc-client < 0 # tried irc-client-1.1.2.3, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
+        - irc-client < 0 # tried irc-client-1.1.2.3, but its *library* requires tls >=1.3 && < 1.6 and the snapshot contains tls-1.8.0
+        - irc-client < 0 # tried irc-client-1.1.2.3, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - irc-conduit < 0 # tried irc-conduit-0.3.0.6, but its *library* requires network-conduit-tls >=1.1 && < 1.4 and the snapshot contains network-conduit-tls-1.4.0
+        - irc-conduit < 0 # tried irc-conduit-0.3.0.6, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - irc-conduit < 0 # tried irc-conduit-0.3.0.6, but its *library* requires tls >=1.3 && < 1.6 and the snapshot contains tls-1.8.0
+        - irc-conduit < 0 # tried irc-conduit-0.3.0.6, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* requires attoparsec >=0.13.0.1 && < 0.14 and the snapshot contains attoparsec-0.14.4
+        - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* requires bytestring >=0.10.6.0 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* requires network >=2.6.2.1 && < 2.8 and the snapshot contains network-3.1.4.0
+        - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* requires path >=0.5.7 && < 0.7 and the snapshot contains path-0.9.5
+        - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - it-has < 0 # tried it-has-0.2.0.0, but its *library* requires generic-lens >=2.0.0.0 && < =2.0.0.0 and the snapshot contains generic-lens-2.2.2.0
+        - iterable < 0 # tried iterable-3.0, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
+        - ixset < 0 # tried ixset-1.1.1.2, but its *library* requires the disabled package: syb-with-class
+        - ixset-typed-conversions < 0 # tried ixset-typed-conversions-0.1.2.0, but its *library* requires the disabled package: zipper-extra
+        - javascript-extras < 0 # tried javascript-extras-0.5.0.0, but its *library* requires the disabled package: ghcjs-base-stub
+        - jmacro-rpc-happstack < 0 # tried jmacro-rpc-happstack-0.3.2, but its *library* requires the disabled package: jmacro-rpc
+        - jmacro-rpc-snap < 0 # tried jmacro-rpc-snap-0.3, but its *library* requires the disabled package: jmacro-rpc
+        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires Cabal >=2.4 && < 3.7 and the snapshot contains Cabal-3.10.1.0
+        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires base >=4.5 && < 4.17 and the snapshot contains base-4.18.1.0
+        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires base-compat >=0.9.0 && < 0.12 and the snapshot contains base-compat-0.13.1
+        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires lens >=4.12.3 && < 4.20 and the snapshot contains lens-5.2.3
+        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires text >=0.11.0.6 && < 1.3 and the snapshot contains text-2.0.2
+        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - json-alt < 0 # tried json-alt-1.0.0, but its *library* requires aeson >=1.2.1 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - json-autotype < 0 # tried json-autotype-3.1.2, but its *executable* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires aeson >=1.2.1 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.3.0
+        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires lens >=4.1 && < 4.20 and the snapshot contains lens-5.2.3
+        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires smallcheck >=1.0 && < 1.2 and the snapshot contains smallcheck-1.2.1.1
+        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires text >=1.1 && < 1.4 and the snapshot contains text-2.0.2
+        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires vector >=0.9 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires aeson >=0.7 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires base >=4.3.1 && < 4.13 and the snapshot contains base-4.18.1.0
+        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires bytestring >=0.9.1 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires text >=0.11.2 && < 1.3 and the snapshot contains text-2.0.2
+        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires vector-algorithms >=0.5.4 && < 0.9 and the snapshot contains vector-algorithms-0.9.0.1
+        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires aeson >=0.6 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires base >=4.3 && < 4.15 and the snapshot contains base-4.18.1.0
+        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
+        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires vector >=0.7.1 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.1.0
+        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires http-client >0.5 && < 0.7 and the snapshot contains http-client-0.7.15
+        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires mtl >2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - jvm < 0 # tried jvm-0.6.0, but its *library* requires the disabled package: jni
+        - jvm-batching < 0 # tried jvm-batching-0.2.0, but its *library* requires the disabled package: jni
+        - jvm-streaming < 0 # tried jvm-streaming-0.4.0, but its *library* requires the disabled package: jni
+        - kanji < 0 # tried kanji-3.5.0, but its *library* requires aeson ^>=2.0 and the snapshot contains aeson-2.1.2.1
+        - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* requires aeson >=1.2 && < 1.3 and the snapshot contains aeson-2.1.2.1
+        - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* requires async >=2.1 && < 2.2 and the snapshot contains async-2.2.5
+        - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* requires katip >=0.5 && < 0.6 and the snapshot contains katip-0.8.8.0
+        - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* requires rollbar-hs >=0.2 && < 0.3 and the snapshot contains rollbar-hs-0.3.1.0
+        - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* requires time >=1.8 && < 1.9 and the snapshot contains time-1.12.2
+        - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* requires aeson >=1.0 && < 1.4 and the snapshot contains aeson-2.1.2.1
+        - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* requires katip >=0.5 && < 0.6 and the snapshot contains katip-0.8.8.0
+        - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - koofr-client < 0 # tried koofr-client-1.0.0.3, but its *library* requires aeson >=0.8 && < 2 and the snapshot contains aeson-2.1.2.1
+        - kraken < 0 # tried kraken-0.1.0, but its *library* requires base >=4.5 && < 4.14 and the snapshot contains base-4.18.1.0
+        - kubernetes-webhook-haskell < 0 # tried kubernetes-webhook-haskell-0.2.0.3, but its *library* requires aeson >=1.4.6 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - kubernetes-webhook-haskell < 0 # tried kubernetes-webhook-haskell-0.2.0.3, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - kubernetes-webhook-haskell < 0 # tried kubernetes-webhook-haskell-0.2.0.3, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.0.2
+        - l10n < 0 # tried l10n-0.1.0.1, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.0.2
+        - language-bash < 0 # tried language-bash-0.9.2, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - language-haskell-extract < 0 # tried language-haskell-extract-0.2.4, but its *library* requires template-haskell < 2.16 and the snapshot contains template-haskell-2.20.0.0
+        - language-puppet < 0 # tried language-puppet-1.5.1, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - language-puppet < 0 # tried language-puppet-1.5.1, but its *library* requires servant >=0.9 && < 0.20 and the snapshot contains servant-0.20.1
+        - language-puppet < 0 # tried language-puppet-1.5.1, but its *library* requires servant-client >=0.9 && < 0.20 and the snapshot contains servant-client-0.20
+        - language-puppet < 0 # tried language-puppet-1.5.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - language-puppet < 0 # tried language-puppet-1.5.1, but its *library* requires unix >=2.7 && < 2.8 and the snapshot contains unix-2.8.1.0
+        - language-thrift < 0 # tried language-thrift-0.12.0.1, but its *library* requires ansi-wl-pprint ==0.6.* and the snapshot contains ansi-wl-pprint-1.0.2
+        - large-hashable < 0 # tried large-hashable-0.1.0.4, but its *library* requires template-haskell < 2.15 and the snapshot contains template-haskell-2.20.0.0
+        - lens-accelerate < 0 # tried lens-accelerate-0.3.0.0, but its *library* requires lens ==4.* and the snapshot contains lens-5.2.3
+        - lens-datetime < 0 # tried lens-datetime-0.3, but its *library* requires lens >=3 && < 5 and the snapshot contains lens-5.2.3
+        - lens-family-th < 0 # tried lens-family-th-0.5.2.1, but its *library* requires template-haskell >=2.11 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
+        - lens-process < 0 # tried lens-process-0.4.0.0, but its *library* requires lens >=4.0 && < 5.1 and the snapshot contains lens-5.2.3
+        - lens-simple < 0 # tried lens-simple-0.1.0.9, but its *library* requires lens-family ==1.2.* and the snapshot contains lens-family-2.1.2
+        - lens-simple < 0 # tried lens-simple-0.1.0.9, but its *library* requires lens-family-core ==1.2.* and the snapshot contains lens-family-core-2.1.2
+        - lens-simple < 0 # tried lens-simple-0.1.0.9, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - lenz < 0 # tried lenz-0.4.2.0, but its *library* requires the disabled package: hs-functors
+        - lenz < 0 # tried lenz-0.4.2.0, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - libgraph < 0 # tried libgraph-1.14, but its *library* requires the disabled package: union-find
+        - libinfluxdb < 0 # tried libinfluxdb-0.0.4, but its *library* requires base >=4.8 && < 4.11 and the snapshot contains base-4.18.1.0
+        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.18.1.0
+        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires bytestring ^>=0.10.10.0 and the snapshot contains bytestring-0.11.5.2
+        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires exceptions ==0.10.4 and the snapshot contains exceptions-0.10.7
+        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires monad-time ==0.3.* and the snapshot contains monad-time-0.4.0.0
+        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires text >=1.2.3.2 && < 1.2.5 and the snapshot contains text-2.0.2
+        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires time >=1.9 && < 1.10 and the snapshot contains time-1.12.2
+        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires transformers ^>=0.5.6.2 and the snapshot contains transformers-0.6.1.0
+        - libmpd < 0 # tried libmpd-0.10.0.0, but its *library* requires text >=0.11 && < 2 and the snapshot contains text-2.0.2
+        - libraft < 0 # tried libraft-0.5.0.0, but its *library* requires the disabled package: ekg
+        - licensor < 0 # tried licensor-0.5.0, but its *library* requires Cabal >=3.0.1 && < 3.3 and the snapshot contains Cabal-3.10.1.0
+        - licensor < 0 # tried licensor-0.5.0, but its *library* requires base >=4.13.0 && < 4.15 and the snapshot contains base-4.18.1.0
+        - linear-accelerate < 0 # tried linear-accelerate-0.7.0.0, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2.3
+        - linenoise < 0 # tried linenoise-0.3.2, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
+        - linked-list-with-iterator < 0 # tried linked-list-with-iterator-0.1.1.0, but its *library* requires containers ==0.5.* and the snapshot contains containers-0.6.7
+        - liquid-fixpoint < 0 # tried liquid-fixpoint-8.10.7, but its *library* requires megaparsec >=7.0.0 && < 9 and the snapshot contains megaparsec-9.4.1
+        - liquid-fixpoint < 0 # tried liquid-fixpoint-8.10.7, but its *library* requires rest-rewrite >=0.1.1 && < 0.2 and the snapshot contains rest-rewrite-0.4.2
+        - list-witnesses < 0 # tried list-witnesses-0.1.4.0, but its *library* requires the disabled package: decidable
+        - list-witnesses < 0 # tried list-witnesses-0.1.4.0, but its *library* requires the disabled package: functor-products
+        - llvm-hs-pure < 0 # tried llvm-hs-pure-9.0.0, but its *library* requires bytestring >=0.10 && < 0.11.3 and the snapshot contains bytestring-0.11.5.2
+        - llvm-hs-pure < 0 # tried llvm-hs-pure-9.0.0, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - llvm-hs-pure < 0 # tried llvm-hs-pure-9.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires aeson ^>=1.4 and the snapshot contains aeson-2.1.2.1
+        - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires ansi-terminal >=0.7 && < 1.0 and the snapshot contains ansi-terminal-1.0
+        - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires mmorph ^>=1.1 and the snapshot contains mmorph-1.2.0
+        - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires mtl ^>=2.2.1 and the snapshot contains mtl-2.3.1
+        - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires o-clock ^>=1.1 and the snapshot contains o-clock-1.4.0
+        - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires text ^>=1.2.2.0 and the snapshot contains text-2.0.2
+        - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires transformers ^>=0.5.2 and the snapshot contains transformers-0.6.1.0
+        - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires universum ^>=1.6.0 and the snapshot contains universum-1.8.2
+        - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires vector ^>=0.12 and the snapshot contains vector-0.13.1.0
+        - loopbreaker < 0 # tried loopbreaker-0.1.1.1, but its *library* requires ghc >=8.6 && < 8.9 and the snapshot contains ghc-9.6.3
+        - lrucaching < 0 # tried lrucaching-0.3.3, but its *library* requires base-compat >=0.9 && < 0.13 and the snapshot contains base-compat-0.13.1
+        - lrucaching < 0 # tried lrucaching-0.3.3, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires aeson >=1.0.2.1 && < 2 and the snapshot contains aeson-2.1.2.1
+        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires network >=2.6.3.2 && < 3 and the snapshot contains network-3.1.4.0
+        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires servant >=0.11 && < 0.14 and the snapshot contains servant-0.20.1
+        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires servant-client >=0.11 && < 0.14 and the snapshot contains servant-client-0.20
+        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires text >=1.2.2.2 && < 2 and the snapshot contains text-2.0.2
+        - lxd-client-config < 0 # tried lxd-client-config-0.1.0.1, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
+        - lzma-conduit < 0 # tried lzma-conduit-1.2.3, but its *library* requires resourcet >=1.1.0 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - lzma-conduit < 0 # tried lzma-conduit-1.2.3, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - machines-directory < 0 # tried machines-directory-7.0.0.0, but its *library* requires the disabled package: machines-io
+        - machines-directory < 0 # tried machines-directory-7.0.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - magicbane < 0 # tried magicbane-0.5.1, but its *library* requires the disabled package: ekg-wai
+        - mail-pool < 0 # tried mail-pool-2.2.3, but its *library* requires the disabled package: HaskellNet-SSL
+        - makefile < 0 # tried makefile-1.1.0.0, but its *library* requires attoparsec >=0.12 && < 0.14 and the snapshot contains attoparsec-0.14.4
+        - makefile < 0 # tried makefile-1.1.0.0, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
+        - mallard < 0 # tried mallard-0.6.1.1, but its *library* requires megaparsec >=6 && < 7 and the snapshot contains megaparsec-9.4.1
+        - marvin < 0 # tried marvin-0.2.5, but its *library* requires aeson >=0.11 && < 1.3 and the snapshot contains aeson-2.1.2.1
+        - marvin < 0 # tried marvin-0.2.5, but its *library* requires http-client >=0.4 && < 0.6 and the snapshot contains http-client-0.7.15
+        - marvin < 0 # tried marvin-0.2.5, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2.3
+        - marvin < 0 # tried marvin-0.2.5, but its *library* requires text-icu >=0.6 && < 0.8 and the snapshot contains text-icu-0.8.0.4
+        - marvin < 0 # tried marvin-0.2.5, but its *library* requires the disabled package: marvin-interpolate
+        - massiv-persist < 0 # tried massiv-persist-1.0.0.3, but its *library* requires the disabled package: persist
+        - mbox < 0 # tried mbox-0.3.4, but its *library* requires time < 1.10 and the snapshot contains time-1.12.2
+        - mbug < 0 # tried mbug-1.3.2, but its *library* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - mbug < 0 # tried mbug-1.3.2, but its *library* requires extra >=1.6.14 && < 1.7 and the snapshot contains extra-1.7.14
+        - mbug < 0 # tried mbug-1.3.2, but its *library* requires formatting >=6.3.7 && < 6.4 and the snapshot contains formatting-7.2.0
+        - mbug < 0 # tried mbug-1.3.2, but its *library* requires http-client >=0.5.14 && < 0.6 and the snapshot contains http-client-0.7.15
+        - mbug < 0 # tried mbug-1.3.2, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - mbug < 0 # tried mbug-1.3.2, but its *library* requires optparse-applicative >=0.14.3.0 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
+        - mbug < 0 # tried mbug-1.3.2, but its *library* requires scalpel-core >=0.5.1 && < 0.6 and the snapshot contains scalpel-core-0.6.2.2
+        - mbug < 0 # tried mbug-1.3.2, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
+        - mbug < 0 # tried mbug-1.3.2, but its *library* requires time >=1.8.0.2 && < 1.9 and the snapshot contains time-1.12.2
+        - medea < 0 # tried medea-1.2.0, but its *library* requires aeson >=1.4.6.0 && < 2.0.0.0 and the snapshot contains aeson-2.1.2.1
+        - medea < 0 # tried medea-1.2.0, but its *library* requires algebraic-graphs ^>=0.5 and the snapshot contains algebraic-graphs-0.7
+        - medea < 0 # tried medea-1.2.0, but its *library* requires bytestring ^>=0.10.8.2 and the snapshot contains bytestring-0.11.5.2
+        - medea < 0 # tried medea-1.2.0, but its *library* requires free ^>=5.1.3 and the snapshot contains free-5.2
+        - medea < 0 # tried medea-1.2.0, but its *library* requires hashable >=1.2.7.0 && < 1.4.0.0 and the snapshot contains hashable-1.4.3.0
+        - medea < 0 # tried medea-1.2.0, but its *library* requires mtl ^>=2.2.2 and the snapshot contains mtl-2.3.1
+        - medea < 0 # tried medea-1.2.0, but its *library* requires text ^>=1.2.3.1 and the snapshot contains text-2.0.2
+        - medea < 0 # tried medea-1.2.0, but its *library* requires vector ^>=0.12.0.3 and the snapshot contains vector-0.13.1.0
+        - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.1.0
+        - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
+        - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
+        - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - menshen < 0 # tried menshen-0.0.3, but its *library* requires regex-tdfa >=1.2.3.1 && < 1.3 and the snapshot contains regex-tdfa-1.3.2.2
+        - menshen < 0 # tried menshen-0.0.3, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
+        - mercury-api < 0 # tried mercury-api-0.1.0.2, but its *executable* requires optparse-applicative >=0.13 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
+        - mercury-api < 0 # tried mercury-api-0.1.0.2, but its *library* requires ansi-terminal >=0.6.2.3 && < 0.12 and the snapshot contains ansi-terminal-1.0
+        - mercury-api < 0 # tried mercury-api-0.1.0.2, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - messagepack-rpc < 0 # tried messagepack-rpc-0.5.1, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.5.2
+        - messagepack-rpc < 0 # tried messagepack-rpc-0.5.1, but its *library* requires containers ==0.5.* and the snapshot contains containers-0.6.7
+        - microlens-process < 0 # tried microlens-process-0.2.0.2, but its *library* requires microlens >=0.3 && < 0.4.13 and the snapshot contains microlens-0.4.13.1
+        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires http-api-data >=0.3 && < 0.5 and the snapshot contains http-api-data-0.5.1
+        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.15
+        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.1.1
+        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires servant >=0.13 && < 0.16 and the snapshot contains servant-0.20.1
+        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires servant-client >=0.13 && < 0.16 and the snapshot contains servant-client-0.20
+        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
+        - milena < 0 # tried milena-0.5.4.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - milena < 0 # tried milena-0.5.4.0, but its *library* requires lens >=4.4 && < 4.20 and the snapshot contains lens-5.2.3
+        - milena < 0 # tried milena-0.5.4.0, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - milena < 0 # tried milena-0.5.4.0, but its *library* requires network >=2.4 && < 3.0 and the snapshot contains network-3.1.4.0
+        - milena < 0 # tried milena-0.5.4.0, but its *library* requires random >=1.0 && < 1.2 and the snapshot contains random-1.2.1.1
+        - milena < 0 # tried milena-0.5.4.0, but its *library* requires resource-pool >=0.2.3.2 && < 0.3 and the snapshot contains resource-pool-0.4.0.0
+        - milena < 0 # tried milena-0.5.4.0, but its *library* requires semigroups >=0.16.2.2 && < 0.19 and the snapshot contains semigroups-0.20
+        - milena < 0 # tried milena-0.5.4.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - mini-egison < 0 # tried mini-egison-1.0.0, but its *library* requires the disabled package: egison-pattern-src-th-mode
+        - minio-hs < 0 # tried minio-hs-1.7.0, but its *library* requires the disabled package: connection
+        - model < 0 # tried model-0.5, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - modify-fasta < 0 # tried modify-fasta-0.8.3.0, but its *library* requires the disabled package: regex-tdfa-text
+        - moffy-samples-gtk4 < 0 # tried moffy-samples-gtk4-0.1.0.0, but its *executable* requires the disabled package: moffy-samples-gtk4-run
+        - mole < 0 # tried mole-0.0.7, but its *executable* requires base >=4.11 && < 4.15 and the snapshot contains base-4.18.1.0
+        - monad-bayes < 0 # tried monad-bayes-1.2.0, but its *executable* requires transformers ^>=0.5.6 and the snapshot contains transformers-0.6.1.0
+        - monad-bayes < 0 # tried monad-bayes-1.2.0, but its *library* requires base >=4.15 && < 4.18 and the snapshot contains base-4.18.1.0
+        - monad-bayes < 0 # tried monad-bayes-1.2.0, but its *library* requires brick >=1.0 && < 2.0 and the snapshot contains brick-2.1.1
+        - monad-bayes < 0 # tried monad-bayes-1.2.0, but its *library* requires free >=5.0.2 && < 5.2 and the snapshot contains free-5.2
+        - monad-bayes < 0 # tried monad-bayes-1.2.0, but its *library* requires mtl ^>=2.2.2 and the snapshot contains mtl-2.3.1
+        - monad-bayes < 0 # tried monad-bayes-1.2.0, but its *library* requires vty ^>=5.38 and the snapshot contains vty-6.1
+        - monad-journal < 0 # tried monad-journal-0.8.1, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - monad-journal < 0 # tried monad-journal-0.8.1, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - monad-logger-prefix < 0 # tried monad-logger-prefix-0.1.12, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - monad-logger-prefix < 0 # tried monad-logger-prefix-0.1.12, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
+        - monad-logger-prefix < 0 # tried monad-logger-prefix-0.1.12, but its *library* requires transformers >=0.4.0 && < 0.5.7 and the snapshot contains transformers-0.6.1.0
+        - monad-mock < 0 # tried monad-mock-0.2.0.0, but its *library* requires template-haskell >=2.10.0.0 && < 2.13 and the snapshot contains template-haskell-2.20.0.0
+        - monad-products < 0 # tried monad-products-4.0.1, but its *library* requires semigroupoids >=4 && < 6 and the snapshot contains semigroupoids-6.0.0.1
+        - monad-skeleton < 0 # tried monad-skeleton-0.2, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.18.1.0
+        - monad-unlift-ref < 0 # tried monad-unlift-ref-0.2.1, but its *library* requires the disabled package: monad-unlift
+        - monadic-arrays < 0 # tried monadic-arrays-0.2.2, but its *library* requires transformers >=0.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - morpheus-graphql < 0 # tried morpheus-graphql-0.27.3, but its *library* requires the disabled package: morpheus-graphql-code-gen
+        - morpheus-graphql-code-gen < 0 # tried morpheus-graphql-code-gen-0.27.3, but its *executable* requires optparse-applicative >=0.12.0 && < 0.18.0 and the snapshot contains optparse-applicative-0.18.1.0
+        - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* requires blaze-builder ==0.3.* and the snapshot contains blaze-builder-0.4.2.3
+        - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* requires filepath >=1.1 && < 1.4 and the snapshot contains filepath-1.4.100.4
+        - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* requires msgpack ==0.7.* and the snapshot contains msgpack-1.0.1.0
+        - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* requires shakespeare-text ==1.0.* and the snapshot contains shakespeare-text-1.1.0
+        - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* requires template-haskell >=2.5 && < 2.9 and the snapshot contains template-haskell-2.20.0.0
+        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires base >=4.8 && < 4.13 and the snapshot contains base-4.18.1.0
+        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires binary-conduit >=1.2.3 && < 1.3 and the snapshot contains binary-conduit-1.3.1
+        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires bytestring >=0.10.4 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires conduit >=1.2.3.1 && < 1.3 and the snapshot contains conduit-1.3.5
+        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires conduit-extra >=1.1.3.4 && < 1.3 and the snapshot contains conduit-extra-1.3.6
+        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires network >=2.6 && < 2.9 || >=3.0 && < 3.1 and the snapshot contains network-3.1.4.0
+        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires random >=1.1 && < 1.2 and the snapshot contains random-1.2.1.1
+        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - mstate < 0 # tried mstate-0.2.10, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - mwc-random-accelerate < 0 # tried mwc-random-accelerate-0.2.0.0, but its *library* requires the disabled package: accelerate
+        - mwc-random-monad < 0 # tried mwc-random-monad-0.7.3.1, but its *library* requires the disabled package: monad-primitive
+        - mysql-haskell-openssl < 0 # tried mysql-haskell-openssl-0.8.3.1, but its *library* requires mysql-haskell >=0.8.3 && < 0.8.5 and the snapshot contains mysql-haskell-1.1.3
+        - mysql-haskell-openssl < 0 # tried mysql-haskell-openssl-0.8.3.1, but its *library* requires the disabled package: tcp-streams
+        - n2o-web < 0 # tried n2o-web-0.11.2, but its *library* requires the disabled package: n2o-protocols
+        - nakadi-client < 0 # tried nakadi-client-0.7.0.0, but its *library* requires resourcet >=1.2.0 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - naqsha < 0 # tried naqsha-0.3.0.1, but its *library* requires base >=4.10 && < 4.13 and the snapshot contains base-4.18.1.0
+        - naqsha < 0 # tried naqsha-0.3.0.1, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - naqsha < 0 # tried naqsha-0.3.0.1, but its *library* requires vector >=0.12 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - network-anonymous-tor < 0 # tried network-anonymous-tor-0.11.0, but its *library* requires the disabled package: hexstring
+        - network-anonymous-tor < 0 # tried network-anonymous-tor-0.11.0, but its *library* requires the disabled package: network-attoparsec
+        - network-msgpack-rpc < 0 # tried network-msgpack-rpc-0.0.6, but its *library* requires network < 3 and the snapshot contains network-3.1.4.0
+        - next-ref < 0 # tried next-ref-0.1.0.2, but its *library* requires stm >=2.2 && < 2.5 and the snapshot contains stm-2.5.1.0
+        - nonemptymap < 0 # tried nonemptymap-0.0.6.0, but its *library* requires semigroupoids >=5 && < 6 and the snapshot contains semigroupoids-6.0.0.1
+        - normalization-insensitive < 0 # tried normalization-insensitive-2.0.2, but its *library* requires text >=1.1.1 && < 1.3 and the snapshot contains text-2.0.2
+        - nri-env-parser < 0 # tried nri-env-parser-0.1.0.8, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.18.1.0
+        - nri-env-parser < 0 # tried nri-env-parser-0.1.0.8, but its *library* requires the disabled package: nri-prelude
+        - nri-http < 0 # tried nri-http-0.3.0.0, but its *library* requires aeson >=1.4.6.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
+        - nri-http < 0 # tried nri-http-0.3.0.0, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.18.1.0
+        - nri-http < 0 # tried nri-http-0.3.0.0, but its *library* requires the disabled package: nri-prelude
+        - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires aeson >=1.4.6.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
+        - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.18.1.0
+        - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires hw-kafka-client >=4.0.3 && < 5.0 and the snapshot contains hw-kafka-client-5.3.0
+        - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires the disabled package: nri-prelude
+        - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires unix >=2.7.2.2 && < 2.8.0.0 and the snapshot contains unix-2.8.1.0
+        - nri-observability < 0 # tried nri-observability-0.1.1.4, but its *library* requires aeson >=1.4.6.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
+        - nri-observability < 0 # tried nri-observability-0.1.1.4, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.18.1.0
+        - nri-observability < 0 # tried nri-observability-0.1.1.4, but its *library* requires the disabled package: nri-prelude
+        - nri-postgresql < 0 # tried nri-postgresql-0.1.0.4, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.18.1.0
+        - nri-postgresql < 0 # tried nri-postgresql-0.1.0.4, but its *library* requires resource-pool >=0.2.0.0 && < 0.3 and the snapshot contains resource-pool-0.4.0.0
+        - nri-postgresql < 0 # tried nri-postgresql-0.1.0.4, but its *library* requires resourcet >=1.2.0 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - nri-postgresql < 0 # tried nri-postgresql-0.1.0.4, but its *library* requires template-haskell >=2.15.0.0 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
+        - nri-postgresql < 0 # tried nri-postgresql-0.1.0.4, but its *library* requires the disabled package: nri-prelude
+        - nri-redis < 0 # tried nri-redis-0.1.0.4, but its *library* requires aeson >=1.4.6.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
+        - nri-redis < 0 # tried nri-redis-0.1.0.4, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.18.1.0
+        - nri-redis < 0 # tried nri-redis-0.1.0.4, but its *library* requires resourcet >=1.2.0 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - nri-redis < 0 # tried nri-redis-0.1.0.4, but its *library* requires the disabled package: nri-prelude
+        - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires aeson >=1.4.6.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
+        - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.18.1.0
+        - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires servant >=0.16.2 && < 0.19 and the snapshot contains servant-0.20.1
+        - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires servant-server >=0.16.2 && < 0.19 and the snapshot contains servant-server-0.20
+        - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires the disabled package: nri-prelude
+        - numhask-prelude < 0 # tried numhask-prelude-0.5.0, but its *library* requires numhask >=0.3 && < 0.6 and the snapshot contains numhask-0.11.1.0
+        - ochintin-daicho < 0 # tried ochintin-daicho-0.3.4.2, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - oeis < 0 # tried oeis-0.3.10, but its *library* requires HTTP >=4000.2 && < 4000.4 and the snapshot contains HTTP-4000.4.1
+        - oset < 0 # tried oset-0.4.0.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.18.1.0
+        - packdeps < 0 # tried packdeps-0.6.0.0, but its *executable* requires optparse-applicative >=0.14 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
+        - packdeps < 0 # tried packdeps-0.6.0.0, but its *library* requires Cabal >=3.2 && < 3.3 and the snapshot contains Cabal-3.10.1.0
+        - pairing < 0 # tried pairing-1.1.0, but its *library* requires MonadRandom >=0.5.1 && < 0.6 and the snapshot contains MonadRandom-0.6
+        - pairing < 0 # tried pairing-1.1.0, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - pairing < 0 # tried pairing-1.1.0, but its *library* requires groups >=0.4.1 && < 0.5 and the snapshot contains groups-0.5.3
+        - pairing < 0 # tried pairing-1.1.0, but its *library* requires protolude >=0.2 && < 0.3 and the snapshot contains protolude-0.3.3
+        - pandoc-csv2table < 0 # tried pandoc-csv2table-1.0.9, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
+        - pandoc-symreg < 0 # tried pandoc-symreg-0.2.1.3, but its *library* requires hegg >=0.3.0 && < 0.4 and the snapshot contains hegg-0.5.0.0
+        - papillon < 0 # tried papillon-0.1.1.1, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.5.2
+        - papillon < 0 # tried papillon-0.1.1.1, but its *library* requires monads-tf ==0.1.* and the snapshot contains monads-tf-0.3.0.1
+        - papillon < 0 # tried papillon-0.1.1.1, but its *library* requires template-haskell ==2.15.* and the snapshot contains template-haskell-2.20.0.0
+        - papillon < 0 # tried papillon-0.1.1.1, but its *library* requires transformers ==0.5.* and the snapshot contains transformers-0.6.1.0
+        - paripari < 0 # tried paripari-0.7.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - paripari < 0 # tried paripari-0.7.0.0, but its *library* requires parser-combinators >=1.0 && < 1.3 and the snapshot contains parser-combinators-1.3.0
+        - paripari < 0 # tried paripari-0.7.0.0, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
+        - pasta-curves < 0 # tried pasta-curves-0.0.1.0, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.18.1.0
+        - pasta-curves < 0 # tried pasta-curves-0.0.1.0, but its *library* requires bytestring >=0.10 && < 0.11.4 and the snapshot contains bytestring-0.11.5.2
+        - pasta-curves < 0 # tried pasta-curves-0.0.1.0, but its *library* requires memory >=0.16 && < 0.18 and the snapshot contains memory-0.18.0
+        - path-formatting < 0 # tried path-formatting-0.1.0.0, but its *library* requires formatting >=7.0.0 && < 7.2 and the snapshot contains formatting-7.2.0
+        - path-text-utf8 < 0 # tried path-text-utf8-0.0.2.0, but its *library* requires the disabled package: file-io
+        - pattern-arrows < 0 # tried pattern-arrows-0.0.2, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
+        - peggy < 0 # tried peggy-0.3.2, but its *library* requires ListLike ==3.1.* and the snapshot contains ListLike-4.7.8.2
+        - peggy < 0 # tried peggy-0.3.2, but its *library* requires hashtables ==1.0.* and the snapshot contains hashtables-1.3.1
+        - peggy < 0 # tried peggy-0.3.2, but its *library* requires monad-control ==0.3.* and the snapshot contains monad-control-1.0.3.1
+        - peggy < 0 # tried peggy-0.3.2, but its *library* requires template-haskell >=2.5 && < 2.9 and the snapshot contains template-haskell-2.20.0.0
+        - perfect-vector-shuffle < 0 # tried perfect-vector-shuffle-0.1.1.1, but its *library* requires MonadRandom >=0.5.1.1 && < 0.6 and the snapshot contains MonadRandom-0.6
+        - perfect-vector-shuffle < 0 # tried perfect-vector-shuffle-0.1.1.1, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.18.1.0
+        - perfect-vector-shuffle < 0 # tried perfect-vector-shuffle-0.1.1.1, but its *library* requires primitive >=0.6.4 && < 0.8 and the snapshot contains primitive-0.8.0.0
+        - perfect-vector-shuffle < 0 # tried perfect-vector-shuffle-0.1.1.1, but its *library* requires vector >=0.12.0 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - persist < 0 # tried persist-0.1.1.5, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - persistent-mtl < 0 # tried persistent-mtl-0.5.0.1, but its *library* requires the disabled package: unliftio-pool
+        - persistent-mysql-haskell < 0 # tried persistent-mysql-haskell-0.6.0, but its *library* requires mysql-haskell >=0.8.0.0 && < 1.0 and the snapshot contains mysql-haskell-1.1.3
+        - persistent-mysql-haskell < 0 # tried persistent-mysql-haskell-0.6.0, but its *library* requires tls >=1.3.5 && < 1.5 and the snapshot contains tls-1.8.0
+        - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires postgresql-simple >=0.6 && < 0.7 and the snapshot contains postgresql-simple-0.7.0.0
+        - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires random >=1.0 && < 1.2 and the snapshot contains random-1.2.1.1
+        - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires scotty >=0.11.0 && < 0.12 and the snapshot contains scotty-0.20.1
+        - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires text >=1.1.0 && < 2 and the snapshot contains text-2.0.2
+        - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - picedit < 0 # tried picedit-0.2.3.0, but its *executable* requires the disabled package: cli
+        - picedit < 0 # tried picedit-0.2.3.0, but its *library* requires JuicyPixels >=3.2.8 && < 3.3 and the snapshot contains JuicyPixels-3.3.8
+        - picedit < 0 # tried picedit-0.2.3.0, but its *library* requires hmatrix >=0.17.0.2 && < 0.19 and the snapshot contains hmatrix-0.20.2
+        - picedit < 0 # tried picedit-0.2.3.0, but its *library* requires vector >=0.11.0.0 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - picosat < 0 # tried picosat-0.1.6, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires Cabal ==2.2.* and the snapshot contains Cabal-3.10.1.0
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires aeson >=1.3 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires base ==4.11.* and the snapshot contains base-4.18.1.0
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires binary-orphans ==0.1.* and the snapshot contains binary-orphans-1.0.4.1
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires containers ==0.5.* and the snapshot contains containers-0.6.7
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires hashable ==1.2.* and the snapshot contains hashable-1.4.3.0
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires shake ==0.16.* and the snapshot contains shake-0.19.7
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires text ==1.2.* and the snapshot contains text-2.0.2
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires transformers ==0.5.* and the snapshot contains transformers-0.6.1.0
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires yaml >=0.8 && < 0.11 and the snapshot contains yaml-0.11.11.2
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires Cabal ==2.2.* and the snapshot contains Cabal-3.10.1.0
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires base ==4.11.* and the snapshot contains base-4.18.1.0
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires base64-bytestring ==1.0.* and the snapshot contains base64-bytestring-1.2.1.0
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.5.2
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires containers ==0.5.* and the snapshot contains containers-0.6.7
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires hashable ==1.2.* and the snapshot contains hashable-1.4.3.0
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires http-client ==0.5.* and the snapshot contains http-client-0.7.15
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires shake >=0.16.4 && < 0.17 and the snapshot contains shake-0.19.7
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires text ==1.2.* and the snapshot contains text-2.0.2
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires unix ==2.7.* and the snapshot contains unix-2.8.1.0
+        - pinboard < 0 # tried pinboard-0.10.3.0, but its *library* requires bytestring >=0.10.0 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - pinboard < 0 # tried pinboard-0.10.3.0, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
+        - pinboard < 0 # tried pinboard-0.10.3.0, but its *library* requires vector >=0.10.9 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - pipes-category < 0 # tried pipes-category-0.3.0.0, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2.3
+        - pipes-misc < 0 # tried pipes-misc-0.5.0.0, but its *library* requires the disabled package: pipes-category
+        - pipes-network-tls < 0 # tried pipes-network-tls-0.4, but its *library* requires the disabled package: network-simple-tls
+        - pipes-network-tls < 0 # tried pipes-network-tls-0.4, but its *library* requires the disabled package: pipes-network
+        - pixelated-avatar-generator < 0 # tried pixelated-avatar-generator-0.1.3, but its *executable* requires the disabled package: cli
+        - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires base >=4.7 && < 4.13 || ^>=4.13 and the snapshot contains base-4.18.1.0
+        - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires haskell-src-exts-simple >=1.18 && < 1.21 || ^>=1.21 and the snapshot contains haskell-src-exts-simple-1.23.0.0
+        - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires mtl >=2 && < 2.2 || ^>=2.2 and the snapshot contains mtl-2.3.1
+        - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires transformers >=0.2 && < 0.5 || ^>=0.5 and the snapshot contains transformers-0.6.1.0
+        - polysemy-extra < 0 # tried polysemy-extra-0.2.1.0, but its *library* requires polysemy >=1.4 && < 1.8 and the snapshot contains polysemy-1.9.1.3
+        - polysemy-fskvstore < 0 # tried polysemy-fskvstore-0.1.2.0, but its *library* requires polysemy >=1.4.0.0 && < 1.8 and the snapshot contains polysemy-1.9.1.3
+        - polysemy-kvstore < 0 # tried polysemy-kvstore-0.1.3.0, but its *library* requires polysemy >=1.3.0.0 && < 1.8 and the snapshot contains polysemy-1.9.1.3
+        - polysemy-kvstore-jsonfile < 0 # tried polysemy-kvstore-jsonfile-0.1.1.0, but its *library* requires aeson >=1.0 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - polysemy-kvstore-jsonfile < 0 # tried polysemy-kvstore-jsonfile-0.1.1.0, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.18.1.0
+        - polysemy-kvstore-jsonfile < 0 # tried polysemy-kvstore-jsonfile-0.1.1.0, but its *library* requires polysemy >=1.3.0.0 && < 1.7 and the snapshot contains polysemy-1.9.1.3
+        - polysemy-methodology < 0 # tried polysemy-methodology-0.2.2.0, but its *library* requires base >=4.7 && < 4.18 and the snapshot contains base-4.18.1.0
+        - polysemy-methodology < 0 # tried polysemy-methodology-0.2.2.0, but its *library* requires polysemy >=1.3.0.0 && < 1.8 and the snapshot contains polysemy-1.9.1.3
+        - polysemy-path < 0 # tried polysemy-path-0.2.1.0, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.18.1.0
+        - polysemy-path < 0 # tried polysemy-path-0.2.1.0, but its *library* requires polysemy >=1.3.0.0 && < 1.7 and the snapshot contains polysemy-1.9.1.3
+        - polysemy-several < 0 # tried polysemy-several-0.1.1.0, but its *library* requires base >=4.7 && < 4.18 and the snapshot contains base-4.18.1.0
+        - polysemy-several < 0 # tried polysemy-several-0.1.1.0, but its *library* requires polysemy >=1.3.0.0 && < 1.8 and the snapshot contains polysemy-1.9.1.3
+        - polysemy-socket < 0 # tried polysemy-socket-0.0.2.0, but its *library* requires polysemy >=1.3.0.0 && < 1.7 and the snapshot contains polysemy-1.9.1.3
+        - polysemy-uncontrolled < 0 # tried polysemy-uncontrolled-0.1.1.1, but its *library* requires base >=4.7 && < 4.18 and the snapshot contains base-4.18.1.0
+        - polysemy-uncontrolled < 0 # tried polysemy-uncontrolled-0.1.1.1, but its *library* requires polysemy >=1.3.0.0 && < 1.8 and the snapshot contains polysemy-1.9.1.3
+        - polysemy-video < 0 # tried polysemy-video-0.2.0.1, but its *library* requires formatting >=7.0.0 && < 7.2 and the snapshot contains formatting-7.2.0
+        - polysemy-video < 0 # tried polysemy-video-0.2.0.1, but its *library* requires polysemy >=1.3.0.0 && < 1.7 and the snapshot contains polysemy-1.9.1.3
+        - polysemy-video < 0 # tried polysemy-video-0.2.0.1, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - polysemy-video < 0 # tried polysemy-video-0.2.0.1, but its *library* requires turtle >=1.0 && < 1.6 and the snapshot contains turtle-1.6.2
+        - polysemy-vinyl < 0 # tried polysemy-vinyl-0.1.5.0, but its *library* requires polysemy >=1.3 && < 1.7 and the snapshot contains polysemy-1.9.1.3
+        - polysemy-vinyl < 0 # tried polysemy-vinyl-0.1.5.0, but its *library* requires vinyl >=0.10.0 && < 0.14 and the snapshot contains vinyl-0.14.3
+        - polysemy-zoo < 0 # tried polysemy-zoo-0.8.2.0, but its *library* requires ghc-prim >=0.5.2 && < 0.10 and the snapshot contains ghc-prim-0.10.0
+        - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* requires base >=4.6.0.0 && < 4.15 and the snapshot contains base-4.18.1.0
+        - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* requires containers >=0.5.9.2 && < =0.6.4.1 and the snapshot contains containers-0.6.7
+        - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* requires ghc-prim >=0.4 && < 0.7 and the snapshot contains ghc-prim-0.10.0
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires HTTP >=4000.3.7 && < 4000.4 and the snapshot contains HTTP-4000.4.1
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires aeson >=1.4.7 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires base >=4.9 && < 4.16 and the snapshot contains base-4.18.1.0
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires hasql >=1.4 && < 1.5 and the snapshot contains hasql-1.6.3.4
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires hasql-dynamic-statements ==0.3.1 and the snapshot contains hasql-dynamic-statements-0.3.1.2
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires hasql-pool >=0.5 && < 0.6 and the snapshot contains hasql-pool-0.10
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires jose >=0.8.1 && < 0.9 and the snapshot contains jose-0.10.0.1
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires lens >=4.14 && < 5.1 and the snapshot contains lens-5.2.3
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires lens-aeson >=1.0.1 && < 1.2 and the snapshot contains lens-aeson-1.2.3
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires optparse-applicative >=0.13 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires swagger2 >=2.4 && < 2.7 and the snapshot contains swagger2-2.8.7
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires text >=1.2.2 && < 1.3 and the snapshot contains text-2.0.2
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires time >=1.6 && < 1.11 and the snapshot contains time-1.12.2
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - prairie < 0 # tried prairie-0.0.2.0, but its *library* requires template-haskell >=2.15 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - pred-trie < 0 # tried pred-trie-0.6.1, but its *library* requires the disabled package: tries
+        - pretty-diff < 0 # tried pretty-diff-0.4.0.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - printcess < 0 # tried printcess-0.1.0.3, but its *library* requires containers >=0.5.6 && < 0.6 and the snapshot contains containers-0.6.7
+        - printcess < 0 # tried printcess-0.1.0.3, but its *library* requires lens >=4.10 && < 4.16 and the snapshot contains lens-5.2.3
+        - printcess < 0 # tried printcess-0.1.0.3, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - printcess < 0 # tried printcess-0.1.0.3, but its *library* requires transformers >=0.4.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - profiterole < 0 # tried profiterole-0.1, but its *executable* requires the disabled package: ghc-prof
+        - profiteur < 0 # tried profiteur-0.4.7.0, but its *library* requires the disabled package: ghc-prof
+        - prometheus-wai-middleware < 0 # tried prometheus-wai-middleware-1.0.1.0, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
+        - proto-lens-arbitrary < 0 # tried proto-lens-arbitrary-0.1.2.11, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.18.1.0
+        - proto-lens-optparse < 0 # tried proto-lens-optparse-0.1.1.10, but its *library* requires optparse-applicative >=0.13 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - proto-lens-protobuf-types < 0 # tried proto-lens-protobuf-types-0.7.1.2, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.18.1.0
+        - proto-lens-protoc < 0 # tried proto-lens-protoc-0.7.1.1, but its *executable* requires ghc >=8.2 && < 9.3 and the snapshot contains ghc-9.6.3
+        - proto-lens-protoc < 0 # tried proto-lens-protoc-0.7.1.1, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.18.1.0
+        - proto-lens-setup < 0 # tried proto-lens-setup-0.4.0.6, but its *library* requires Cabal >=2.0 && < 3.7 and the snapshot contains Cabal-3.10.1.0
+        - proto-lens-setup < 0 # tried proto-lens-setup-0.4.0.6, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.18.1.0
+        - protocol-buffers-descriptor < 0 # tried protocol-buffers-descriptor-2.4.17, but its *library* requires the disabled package: protocol-buffers
+        - publicsuffix < 0 # tried publicsuffix-0.20200526, but its *library* requires base >=4 && < 4.15 and the snapshot contains base-4.18.1.0
+        - pure-io < 0 # tried pure-io-0.2.1, but its *library* requires base >=4.5 && < 4.11 and the snapshot contains base-4.18.1.0
+        - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *executable* requires optparse-applicative >=0.14.2.0 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
+        - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *library* requires bytestring >=0.10.0.0 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *library* requires the disabled package: cipher-aes128
+        - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires ansi-terminal >=0.6 && < 0.7 and the snapshot contains ansi-terminal-1.0
+        - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires the disabled package: readline
+        - queue-sheet < 0 # tried queue-sheet-0.7.0.2, but its *executable* requires ansi-wl-pprint >=0.6 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
+        - queue-sheet < 0 # tried queue-sheet-0.7.0.2, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - queue-sheet < 0 # tried queue-sheet-0.7.0.2, but its *library* requires transformers >=0.5.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - queue-sheet < 0 # tried queue-sheet-0.7.0.2, but its *library* requires ttc >=1.1 && < 1.3 and the snapshot contains ttc-1.4.0.0
+        - quickbench < 0 # tried quickbench-1.0.1, but its *library* requires the disabled package: docopt
+        - quickcheck-arbitrary-template < 0 # tried quickcheck-arbitrary-template-0.2.1.1, but its *library* requires template-haskell >=2.11 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
+        - quickcheck-combinators < 0 # tried quickcheck-combinators-0.0.6, but its *library* requires the disabled package: unfoldable-restricted
+        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires aeson >=1.0.2.1 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires connection >=0.2.7 && < 0.3 and the snapshot contains connection-0.3.1
+        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires constraints >=0.9.1 && < 0.11 and the snapshot contains constraints-0.13.4
+        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires extensible >=0.4.7.2 && < 0.4.11 and the snapshot contains extensible-0.9
+        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires http-api-data >=0.3.5 && < 0.3.9 and the snapshot contains http-api-data-0.5.1
+        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires http-client >=0.5.5.0 && < 0.6 and the snapshot contains http-client-0.7.15
+        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires lens >=4.15.3 && < 5.0 and the snapshot contains lens-5.2.3
+        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires req >=0.3.0 && < 1.3.0 and the snapshot contains req-3.13.1
+        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
+        - random-source < 0 # tried random-source-0.3.0.13, but its *library* requires base >=4 && < 4.16 and the snapshot contains base-4.18.1.0
+        - random-source < 0 # tried random-source-0.3.0.13, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
+        - rdf < 0 # tried rdf-0.1.0.7, but its *library* requires bytestring >=0.10 && < 0.11.5 and the snapshot contains bytestring-0.11.5.2
+        - reanimate < 0 # tried reanimate-1.1.6.0, but its *library* requires aeson >=1.3.0.0 && < 2 and the snapshot contains aeson-2.1.2.1
+        - reanimate < 0 # tried reanimate-1.1.6.0, but its *library* requires the disabled package: reanimate-svg
+        - rec-smallarray < 0 # tried rec-smallarray-0.1.0.0, but its *library* requires base >=4.12 && < =4.17 and the snapshot contains base-4.18.1.0
+        - rec-smallarray < 0 # tried rec-smallarray-0.1.0.0, but its *library* requires primitive >=0.6.4 && < 0.8 and the snapshot contains primitive-0.8.0.0
+        - record-dot-preprocessor < 0 # tried record-dot-preprocessor-0.2.16, but its *library* requires ghc >=8.6 && < 9.5 and the snapshot contains ghc-9.6.3
+        - redis-io < 0 # tried redis-io-1.1.0, but its *library* requires the disabled package: tinylog
+        - reform < 0 # tried reform-0.2.7.5, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
+        - reform-blaze < 0 # tried reform-blaze-0.2.4.4, but its *library* requires the disabled package: reform
+        - reform-hamlet < 0 # tried reform-hamlet-0.0.5.3, but its *library* requires shakespeare >=2.0 && < 2.1 and the snapshot contains shakespeare-2.1.0.1
+        - reform-hamlet < 0 # tried reform-hamlet-0.0.5.3, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
+        - reform-happstack < 0 # tried reform-happstack-0.2.5.6, but its *library* requires the disabled package: reform
+        - reform-hsp < 0 # tried reform-hsp-0.2.7.2, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
+        - reform-hsp < 0 # tried reform-hsp-0.2.7.2, but its *library* requires the disabled package: hsp
+        - regex-applicative-text < 0 # tried regex-applicative-text-0.1.0.1, but its *library* requires base >=4.3 && < 4.18 and the snapshot contains base-4.18.1.0
+        - regex-pcre-text < 0 # tried regex-pcre-text-0.94.0.1, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.5.2
+        - regex-pcre-text < 0 # tried regex-pcre-text-0.94.0.1, but its *library* requires regex-base ==0.93.* and the snapshot contains regex-base-0.94.0.2
+        - regex-pcre-text < 0 # tried regex-pcre-text-0.94.0.1, but its *library* requires regex-pcre-builtin ==0.94.* and the snapshot contains regex-pcre-builtin-0.95.2.3.8.44
+        - regex-pcre-text < 0 # tried regex-pcre-text-0.94.0.1, but its *library* requires text ==1.2.* and the snapshot contains text-2.0.2
+        - regex-tdfa-text < 0 # tried regex-tdfa-text-1.0.0.3, but its *library* requires regex-base < 0.94 and the snapshot contains regex-base-0.94.0.2
+        - registry < 0 # tried registry-0.6.1.0, but its *library* requires resourcet >=1.1 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - registry < 0 # tried registry-0.6.1.0, but its *library* requires semigroupoids >=5.0 && < 5.4 and the snapshot contains semigroupoids-6.0.0.1
+        - registry-aeson < 0 # tried registry-aeson-0.3.0.0, but its *library* requires text ==1.* and the snapshot contains text-2.0.2
+        - registry-hedgehog < 0 # tried registry-hedgehog-0.8.1.0, but its *library* requires the disabled package: registry
+        - registry-hedgehog-aeson < 0 # tried registry-hedgehog-aeson-0.3.0.0, but its *library* requires tasty-discover >=2 && < 5 and the snapshot contains tasty-discover-5.0.0
+        - registry-hedgehog-aeson < 0 # tried registry-hedgehog-aeson-0.3.0.0, but its *library* requires text ==1.* and the snapshot contains text-2.0.2
+        - registry-options < 0 # tried registry-options-0.2.0.0, but its *library* requires text ==1.* and the snapshot contains text-2.0.2
+        - rel8 < 0 # tried rel8-1.4.1.0, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.1.0
+        - rel8 < 0 # tried rel8-1.4.1.0, but its *library* requires opaleye ^>=0.9.6.1 and the snapshot contains opaleye-0.10.2.0
+        - reorder-expression < 0 # tried reorder-expression-0.1.0.0, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.18.1.0
+        - repa < 0 # tried repa-3.4.1.5, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.18.1.0
+        - repa-algorithms < 0 # tried repa-algorithms-3.4.1.5, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - repa-io < 0 # tried repa-io-3.4.1.2, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *executable* requires aeson >=1.2 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *executable* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.18.1.0
+        - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *library* requires req >=2.0.0 && < 2.1.0 and the snapshot contains req-3.13.1
+        - require < 0 # tried require-0.4.11, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.5.2
+        - require < 0 # tried require-0.4.11, but its *library* requires text >=1.2.3.0 && < 2 and the snapshot contains text-2.0.2
+        - rethinkdb-client-driver < 0 # tried rethinkdb-client-driver-0.0.25, but its *library* requires base < 4.15 and the snapshot contains base-4.18.1.0
+        - rev-state < 0 # tried rev-state-0.1.2, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
+        - rhine < 0 # tried rhine-1.1, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.18.1.0
+        - rhine < 0 # tried rhine-1.1, but its *library* requires the disabled package: dunai
+        - rhine-gloss < 0 # tried rhine-gloss-1.1, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.18.1.0
+        - rhine-gloss < 0 # tried rhine-gloss-1.1, but its *library* requires the disabled package: dunai
+        - riak < 0 # tried riak-1.2.0.0, but its *library* requires aeson >=0.8 && < 1.5.7 and the snapshot contains aeson-2.1.2.1
+        - riak < 0 # tried riak-1.2.0.0, but its *library* requires attoparsec >=0.12.1.6 && < 0.14 and the snapshot contains attoparsec-0.14.4
+        - riak < 0 # tried riak-1.2.0.0, but its *library* requires network >=3.0 && < 3.1 and the snapshot contains network-3.1.4.0
+        - riak < 0 # tried riak-1.2.0.0, but its *library* requires resource-pool ==0.2.* and the snapshot contains resource-pool-0.4.0.0
+        - riak < 0 # tried riak-1.2.0.0, but its *library* requires text ==1.2.* and the snapshot contains text-2.0.2
+        - riak < 0 # tried riak-1.2.0.0, but its *library* requires time >=1.4.2 && < 1.10 and the snapshot contains time-1.12.2
+        - riak < 0 # tried riak-1.2.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - riak < 0 # tried riak-1.2.0.0, but its *library* requires vector >=0.10.12.3 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.15
+        - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires network >=2.6 && < 2.8 and the snapshot contains network-3.1.4.0
+        - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
+        - safe-exceptions-checked < 0 # tried safe-exceptions-checked-0.1.0, but its *library* requires transformers >=0.2.0.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - safe-tensor < 0 # tried safe-tensor-0.2.1.1, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - safe-tensor < 0 # tried safe-tensor-0.2.1.1, but its *library* requires singletons >=2.5 && < 2.8 and the snapshot contains singletons-3.0.2
+        - salak < 0 # tried salak-0.3.6, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - salak < 0 # tried salak-0.3.6, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - salak < 0 # tried salak-0.3.6, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.0.2
+        - salak < 0 # tried salak-0.3.6, but its *library* requires time >=1.8.0 && < 1.11 and the snapshot contains time-1.12.2
+        - salak-toml < 0 # tried salak-toml-0.3.5.3, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.0.2
+        - salak-toml < 0 # tried salak-toml-0.3.5.3, but its *library* requires the disabled package: tomland
+        - salak-toml < 0 # tried salak-toml-0.3.5.3, but its *library* requires time >=1.8.0 && < 1.10 and the snapshot contains time-1.12.2
+        - salak-yaml < 0 # tried salak-yaml-0.3.5.3, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.0.2
+        - scale < 0 # tried scale-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.1.0
+        - scale < 0 # tried scale-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - scale < 0 # tried scale-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
+        - scale < 0 # tried scale-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
+        - scale < 0 # tried scale-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - scale < 0 # tried scale-1.0.0.0, but its *library* requires vector >0.12 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - scalendar < 0 # tried scalendar-1.2.0, but its *library* requires containers >=0.5.7.1 && < 0.6 and the snapshot contains containers-0.6.7
+        - scalendar < 0 # tried scalendar-1.2.0, but its *library* requires text >=1.2.0.0 && < 2 and the snapshot contains text-2.0.2
+        - schematic < 0 # tried schematic-0.5.1.0, but its *library* requires aeson >=1 && < 1.4.3.0 and the snapshot contains aeson-2.1.2.1
+        - schematic < 0 # tried schematic-0.5.1.0, but its *library* requires the disabled package: validationt
+        - selda < 0 # tried selda-0.5.2.0, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
+        - selda < 0 # tried selda-0.5.2.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - selda < 0 # tried selda-0.5.2.0, but its *library* requires time >=1.5 && < 1.12 and the snapshot contains time-1.12.2
+        - selda-json < 0 # tried selda-json-0.1.1.1, but its *library* requires aeson >=1.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
+        - selda-json < 0 # tried selda-json-0.1.1.1, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - selda-postgresql < 0 # tried selda-postgresql-0.1.8.2, but its *library* requires postgresql-binary >=0.12 && < 0.13 and the snapshot contains postgresql-binary-0.13.1.2
+        - selda-postgresql < 0 # tried selda-postgresql-0.1.8.2, but its *library* requires postgresql-libpq >=0.9 && < 0.10 and the snapshot contains postgresql-libpq-0.10.0.0
+        - selda-postgresql < 0 # tried selda-postgresql-0.1.8.2, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - selda-postgresql < 0 # tried selda-postgresql-0.1.8.2, but its *library* requires time >=1.5 && < 1.12 and the snapshot contains time-1.12.2
+        - selda-sqlite < 0 # tried selda-sqlite-0.1.7.2, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - selda-sqlite < 0 # tried selda-sqlite-0.1.7.2, but its *library* requires time >=1.5 && < 1.12 and the snapshot contains time-1.12.2
+        - semigroupoid-extras < 0 # tried semigroupoid-extras-5, but its *library* requires semigroupoids >=5 && < 6 and the snapshot contains semigroupoids-6.0.0.1
+        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires aeson >=0.11 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires base >=4.11 && < 4.14 and the snapshot contains base-4.18.1.0
+        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires http-client >=0.5.6 && < 0.7 and the snapshot contains http-client-0.7.15
+        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires lens >=4.15 && < 4.20 and the snapshot contains lens-5.2.3
+        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires optparse-applicative >=0.12 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
+        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires text >=1.2.2 && < 1.3 and the snapshot contains text-2.0.2
+        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires time >=1.5.0.1 && < 1.10 and the snapshot contains time-1.12.2
+        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires unix < 2.8 and the snapshot contains unix-2.8.1.0
+        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires unix-compat < 0.6 and the snapshot contains unix-compat-0.7.1
+        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - seqloc < 0 # tried seqloc-0.6.1.1, but its *library* requires the disabled package: biocore
+        - serf < 0 # tried serf-0.1.1.0, but its *library* requires text ==1.* and the snapshot contains text-2.0.2
+        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires blaze-builder >=0.4 && < 0.4.1 and the snapshot contains blaze-builder-0.4.2.3
+        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires cryptonite >=0.14 && < 0.25 and the snapshot contains cryptonite-0.30
+        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires exceptions >=0.8 && < 0.9 and the snapshot contains exceptions-0.10.7
+        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires http-api-data ==0.3.* and the snapshot contains http-api-data-0.5.1
+        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires http-types >=0.9 && < 0.12 and the snapshot contains http-types-0.12.4
+        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires memory >=0.11 && < 0.15 and the snapshot contains memory-0.18.0
+        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires servant >=0.5 && < 0.13 and the snapshot contains servant-0.20.1
+        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires servant-server >=0.5 && < 0.13 and the snapshot contains servant-server-0.20
+        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires time >=1.6 && < 1.8.1 and the snapshot contains time-1.12.2
+        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - servant-auth-wordpress < 0 # tried servant-auth-wordpress-1.0.0.2, but its *library* requires servant-server >=0.14 && < 0.20 and the snapshot contains servant-server-0.20
+        - servant-auth-wordpress < 0 # tried servant-auth-wordpress-1.0.0.2, but its *library* requires the disabled package: wordpress-auth
+        - servant-cassava < 0 # tried servant-cassava-0.10.2, but its *library* requires base-compat >=0.9.1 && < 0.13 and the snapshot contains base-compat-0.13.1
+        - servant-cassava < 0 # tried servant-cassava-0.10.2, but its *library* requires servant >=0.7 && < 0.20 and the snapshot contains servant-0.20.1
+        - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires aeson >=1.4.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires servant >=0.15 && < 0.19 and the snapshot contains servant-0.20.1
+        - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
+        - servant-errors < 0 # tried servant-errors-0.1.7.0, but its *library* requires aeson >=1.3 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - servant-errors < 0 # tried servant-errors-0.1.7.0, but its *library* requires base >=4.10.0.0 && < 4.15 and the snapshot contains base-4.18.1.0
+        - servant-js < 0 # tried servant-js-0.9.4.2, but its *executable* requires aeson >=1.4.1.0 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires containers >=0.5.7 && < 0.6.1 and the snapshot contains containers-0.6.7
+        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires formatting >=6.2 && < 6.4 and the snapshot contains formatting-7.2.0
+        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires lens >=4.15 && < 4.18 and the snapshot contains lens-5.2.3
+        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires servant >=0.9 && < 0.17 and the snapshot contains servant-0.20.1
+        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires servant-foreign >=0.9 && < 0.16 and the snapshot contains servant-foreign-0.16
+        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
+        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires QuickCheck >=2.12.6.1 && < 2.14 and the snapshot contains QuickCheck-2.14.3
+        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires base >=4.9 && < 4.14 and the snapshot contains base-4.18.1.0
+        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires base-compat >=0.10.5 && < 0.12 and the snapshot contains base-compat-0.13.1
+        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires servant >=0.17 && < 0.19 and the snapshot contains servant-0.20.1
+        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires servant-server >=0.17 && < 0.19 and the snapshot contains servant-server-0.20
+        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.1.1
+        - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires lens >=4.9 && < 5 and the snapshot contains lens-5.2.3
+        - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires pandoc-types >=1.12 && < 1.18 and the snapshot contains pandoc-types-1.23.1
+        - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires servant-docs >=0.11.1 && < 0.12 and the snapshot contains servant-docs-0.13
+        - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires aeson >=0.8 && < 2 and the snapshot contains aeson-2.1.2.1
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.18.1.0
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires base-compat-batteries >=0.10.1 && < 0.12 and the snapshot contains base-compat-batteries-0.13.1
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires hspec >=2.5.6 && < 2.8 and the snapshot contains hspec-2.11.7
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires servant >=0.17 && < 0.19 and the snapshot contains servant-0.20.1
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires servant-client >=0.17 && < 0.19 and the snapshot contains servant-client-0.20
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires servant-server >=0.17 && < 0.19 and the snapshot contains servant-server-0.20
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.0.2
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires time >=1.5 && < 1.11 and the snapshot contains time-1.12.2
+        - servant-ruby < 0 # tried servant-ruby-0.9.0.0, but its *library* requires servant-foreign >=0.9 && < 0.16 and the snapshot contains servant-foreign-0.16
+        - servant-ruby < 0 # tried servant-ruby-0.9.0.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.18.1.0
+        - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* requires servant >=0.13 && < 0.16 and the snapshot contains servant-0.20.1
+        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.18.1.0
+        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.1.1
+        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires resourcet >=1.1 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires servant >=0.14 && < 0.15 and the snapshot contains servant-0.20.1
+        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires servant-client-core >=0.14 && < 0.15 and the snapshot contains servant-client-core-0.20
+        - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.18.1.0
+        - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.1.1
+        - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires resourcet >=1.1 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires servant-server >=0.13 && < 0.15 and the snapshot contains servant-server-0.20
+        - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* requires base >=4.9 && < 4.14 and the snapshot contains base-4.18.1.0
+        - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* requires servant >=0.15 && < 0.18 and the snapshot contains servant-0.20.1
+        - serversession-backend-persistent < 0 # tried serversession-backend-persistent-2.0.1, but its *library* requires persistent ==2.13.* and the snapshot contains persistent-2.14.6.0
+        - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires exceptions >=0.8.3 && < 0.10.0 and the snapshot contains exceptions-0.10.7
+        - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires the disabled package: sessiontypes
+        - sets < 0 # tried sets-0.0.6.2, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
+        - sexpr-parser < 0 # tried sexpr-parser-0.2.2.0, but its *library* requires megaparsec >=6.5 && < 9.3 and the snapshot contains megaparsec-9.4.1
+        - shikensu < 0 # tried shikensu-0.4.1, but its *library* requires text ==1.* and the snapshot contains text-2.0.2
+        - show-prettyprint < 0 # tried show-prettyprint-0.3.0.1, but its *library* requires trifecta >=1.6 && < 1.8 and the snapshot contains trifecta-2.1.3
+        - shower < 0 # tried shower-0.2.0.3, but its *library* requires base >=4.10 && < 4.18 and the snapshot contains base-4.18.1.0
+        - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires mmorph >=1.0 && < 1.2 and the snapshot contains mmorph-1.2.0
+        - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires text >=0.11.0 && < 2.0.0 and the snapshot contains text-2.0.2
+        - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires time >=1.5 && < 1.10 and the snapshot contains time-1.12.2
+        - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - simple-media-timestamp-formatting < 0 # tried simple-media-timestamp-formatting-0.1.1.0, but its *library* requires formatting >=7.0.0 && < 7.2 and the snapshot contains formatting-7.2.0
+        - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.5.2
+        - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires template-haskell >=2.12 && < 2.16 and the snapshot contains template-haskell-2.20.0.0
+        - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
+        - siphash < 0 # tried siphash-1.0.3, but its *library* requires bytestring < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires aeson >=1.2 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.18.1.0
+        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires constraints >=0.9 && < 0.11 and the snapshot contains constraints-0.13.4
+        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires lens >=4.15 && < 5 and the snapshot contains lens-5.2.3
+        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires random ==1.1.* and the snapshot contains random-1.2.1.1
+        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires vector >=0.12 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - skeletons < 0 # tried skeletons-0.4.0, but its *executable* requires the disabled package: tinytemplate
+        - slack-web < 0 # tried slack-web-1.6.1.0, but its *library* requires base >=4.11 && < 4.18 and the snapshot contains base-4.18.1.0
+        - slack-web < 0 # tried slack-web-1.6.1.0, but its *library* requires servant >=0.16 && < 0.20 and the snapshot contains servant-0.20.1
+        - slack-web < 0 # tried slack-web-1.6.1.0, but its *library* requires servant-client >=0.16 && < 0.20 and the snapshot contains servant-client-0.20
+        - slack-web < 0 # tried slack-web-1.6.1.0, but its *library* requires servant-client-core >=0.16 && < 0.20 and the snapshot contains servant-client-core-0.20
+        - smallcheck-series < 0 # tried smallcheck-series-0.7.1.0, but its *library* requires base >=4.6 && < 4.15 and the snapshot contains base-4.18.1.0
+        - smash < 0 # tried smash-0.1.3, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.18.1.0
+        - smash < 0 # tried smash-0.1.3, but its *library* requires bifunctors ^>=5.5 and the snapshot contains bifunctors-5.6.1
+        - smash < 0 # tried smash-0.1.3, but its *library* requires hashable ^>=1.3 and the snapshot contains hashable-1.4.3.0
+        - smash-aeson < 0 # tried smash-aeson-0.2.0.1, but its *library* requires aeson >=2.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
+        - smash-aeson < 0 # tried smash-aeson-0.2.0.1, but its *library* requires base >=4.1 && < 4.17 and the snapshot contains base-4.18.1.0
+        - smash-lens < 0 # tried smash-lens-0.1.0.3, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.18.1.0
+        - smash-lens < 0 # tried smash-lens-0.1.0.3, but its *library* requires lens >=4.0 && < 5.2 and the snapshot contains lens-5.2.3
+        - smash-microlens < 0 # tried smash-microlens-0.1.0.2, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.18.1.0
+        - smoothie < 0 # tried smoothie-0.4.2.11, but its *library* requires aeson >=0.8 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - smoothie < 0 # tried smoothie-0.4.2.11, but its *library* requires linear >=1.16 && < 1.22 and the snapshot contains linear-1.22
+        - smoothie < 0 # tried smoothie-0.4.2.11, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - smoothie < 0 # tried smoothie-0.4.2.11, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - smtp-mail < 0 # tried smtp-mail-0.3.0.0, but its *library* requires the disabled package: connection
+        - soap < 0 # tried soap-0.2.3.6, but its *library* requires the disabled package: xml-conduit-writer
+        - soap-openssl < 0 # tried soap-openssl-0.1.0.2, but its *library* requires the disabled package: soap
+        - soap-tls < 0 # tried soap-tls-0.1.1.4, but its *library* requires the disabled package: connection
+        - soap-tls < 0 # tried soap-tls-0.1.1.4, but its *library* requires the disabled package: soap
+        - socket-activation < 0 # tried socket-activation-0.1.0.2, but its *library* requires network >=2.3 && < 2.9 and the snapshot contains network-3.1.4.0
+        - sparkle < 0 # tried sparkle-0.7.4, but its *library* requires inline-java >=0.7.0 && < 0.9 and the snapshot contains inline-java-0.10.0
+        - sparkle < 0 # tried sparkle-0.7.4, but its *library* requires jvm >=0.4.0.1 && < 0.5 and the snapshot contains jvm-0.6.0
+        - sparkle < 0 # tried sparkle-0.7.4, but its *library* requires the disabled package: jni
+        - sparse-linear-algebra < 0 # tried sparse-linear-algebra-0.3.1, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.18.1.0
+        - sparse-tensor < 0 # tried sparse-tensor-0.2.1.5, but its *library* requires Cabal >=1.24 && < 3.5 and the snapshot contains Cabal-3.10.1.0
+        - sparse-tensor < 0 # tried sparse-tensor-0.2.1.5, but its *library* requires ad >=4.2 && < 4.5 and the snapshot contains ad-4.5.4
+        - spdx < 0 # tried spdx-1.0.0.3, but its *library* requires Cabal ^>=2.4.0.1 || ^>=3.0.0.0 || ^>=3.2.0.0 || ^>=3.4.0.0 || ^>=3.6.0.0 and the snapshot contains Cabal-3.10.1.0
+        - spdx < 0 # tried spdx-1.0.0.3, but its *library* requires base >=4.3.0.0 && < 4.17 and the snapshot contains base-4.18.1.0
+        - spdx < 0 # tried spdx-1.0.0.3, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - speculation < 0 # tried speculation-1.5.0.3, but its *library* requires stm >=2.1 && < 2.5 and the snapshot contains stm-2.5.1.0
+        - speculation < 0 # tried speculation-1.5.0.3, but its *library* requires transformers >=0.2.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - sqlcli < 0 # tried sqlcli-0.2.2.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - sqlcli-odbc < 0 # tried sqlcli-odbc-0.2.0.1, but its *library* requires the disabled package: sqlcli
+        - sqlite-simple-errors < 0 # tried sqlite-simple-errors-0.6.1.0, but its *library* requires text >=1.2 && < 1.2.4 and the snapshot contains text-2.0.2
+        - srt-attoparsec < 0 # tried srt-attoparsec-0.1.0.0, but its *library* requires mtl >=1.0 && < =2.3 and the snapshot contains mtl-2.3.1
+        - srt-attoparsec < 0 # tried srt-attoparsec-0.1.0.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - srt-dhall < 0 # tried srt-dhall-0.1.0.0, but its *library* requires dhall >=1 && < 1.41 and the snapshot contains dhall-1.42.1
+        - srt-dhall < 0 # tried srt-dhall-0.1.0.0, but its *library* requires formatting >=7.0.0 && < 7.2 and the snapshot contains formatting-7.2.0
+        - srt-dhall < 0 # tried srt-dhall-0.1.0.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - srt-formatting < 0 # tried srt-formatting-0.1.0.0, but its *library* requires formatting >=7.0.0 && < 7.2 and the snapshot contains formatting-7.2.0
+        - stackcollapse-ghc < 0 # tried stackcollapse-ghc-0.0.1.4, but its *executable* requires base >=4.12.0.0 && < 4.16 and the snapshot contains base-4.18.1.0
+        - stackcollapse-ghc < 0 # tried stackcollapse-ghc-0.0.1.4, but its *executable* requires transformers ==0.5.6.* and the snapshot contains transformers-0.6.1.0
+        - stb-image-redux < 0 # tried stb-image-redux-0.2.1.2, but its *library* requires vector >=0.10.12.3 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - stm-lifted < 0 # tried stm-lifted-2.5.0.0, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - stopwatch < 0 # tried stopwatch-0.1.0.6, but its *library* requires transformers >=0.3.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - streaming-cassava < 0 # tried streaming-cassava-0.2.0.0, but its *library* requires streaming-bytestring ==0.2.* and the snapshot contains streaming-bytestring-0.3.2
+        - streamly-bytestring < 0 # tried streamly-bytestring-0.2.0, but its *library* requires bytestring ==0.11.0.* || ==0.11.1.* || ==0.11.2.* || (>=0.11.3.1 && < 0.11.4 and the snapshot contains bytestring-0.11.5.2
+        - streamly-bytestring < 0 # tried streamly-bytestring-0.2.0, but its *library* requires streamly-core ==0.1.0.* and the snapshot contains streamly-core-0.2.0
+        - streamly-examples < 0 # tried streamly-examples-0.1.3, but its *executable* requires base >=4.9 && < 4.18 and the snapshot contains base-4.18.1.0
+        - streamly-examples < 0 # tried streamly-examples-0.1.3, but its *executable* requires streamly ==0.9.0 and the snapshot contains streamly-0.10.0
+        - streamly-examples < 0 # tried streamly-examples-0.1.3, but its *executable* requires streamly-core ==0.1.0 and the snapshot contains streamly-core-0.2.0
+        - streamly-process < 0 # tried streamly-process-0.3.0, but its *library* requires streamly ==0.9.0.* and the snapshot contains streamly-0.10.0
+        - streamly-process < 0 # tried streamly-process-0.3.0, but its *library* requires streamly-core ==0.1.0 and the snapshot contains streamly-core-0.2.0
+        - streamproc < 0 # tried streamproc-1.6.2, but its *library* requires base >=3 && < 4.13 and the snapshot contains base-4.18.1.0
+        - streamt < 0 # tried streamt-0.5.0.1, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
+        - strict-tuple-lens < 0 # tried strict-tuple-lens-0.2, but its *library* requires lens ^>=5 and the snapshot contains lens-5.2.3
+        - string-variants < 0 # tried string-variants-0.3.0.0, but its *library* requires the disabled package: refinery
+        - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires aeson >=0.8 && < 0.10 || >=0.11 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires mtl >=2.1.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires time >=1.4 && < 1.11 and the snapshot contains time-1.12.2
+        - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - stripe-haskell < 0 # tried stripe-haskell-2.6.2, but its *library* requires the disabled package: stripe-core
+        - stripe-haskell < 0 # tried stripe-haskell-2.6.2, but its *library* requires the disabled package: stripe-http-client
+        - stripe-http-client < 0 # tried stripe-http-client-2.6.2, but its *library* requires aeson >=0.8 && < 0.10 || >=0.11 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - stripe-http-client < 0 # tried stripe-http-client-2.6.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - stripe-http-client < 0 # tried stripe-http-client-2.6.2, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
+        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires aeson >=0.8 && < 0.10 || >=0.11 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires hspec >=2.1.0 && < 2.8 and the snapshot contains hspec-2.11.7
+        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires hspec-core >=2.1.0 && < 2.8 and the snapshot contains hspec-core-2.11.7
+        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires mtl >=2.1.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires random >=1.1 && < 1.2 and the snapshot contains random-1.2.1.1
+        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires time >=1.4 && < 1.11 and the snapshot contains time-1.12.2
+        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - strong-path < 0 # tried strong-path-1.1.4.0, but its *library* requires hashable ==1.3.* and the snapshot contains hashable-1.4.3.0
+        - strong-path < 0 # tried strong-path-1.1.4.0, but its *library* requires template-haskell >=2.16 && < 2.18 and the snapshot contains template-haskell-2.20.0.0
+        - strongweak < 0 # tried strongweak-0.6.0, but its *library* requires the disabled package: refined1
+        - structured-cli < 0 # tried structured-cli-2.7.0.1, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - structured-haskell-mode < 0 # tried structured-haskell-mode-1.1.0, but its *executable* requires haskell-src-exts >=1.18 && < 1.20 and the snapshot contains haskell-src-exts-1.23.1
+        - structured-haskell-mode < 0 # tried structured-haskell-mode-1.1.0, but its *executable* requires the disabled package: descriptive
+        - sv < 0 # tried sv-1.4.0.1, but its *library* requires attoparsec >=0.12.1.4 && < 0.14 and the snapshot contains attoparsec-0.14.4
+        - sv < 0 # tried sv-1.4.0.1, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.18.1.0
+        - sv < 0 # tried sv-1.4.0.1, but its *library* requires bifunctors >=5.1 && < 5.6 and the snapshot contains bifunctors-5.6.1
+        - sv < 0 # tried sv-1.4.0.1, but its *library* requires bytestring >=0.9.1.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - sv < 0 # tried sv-1.4.0.1, but its *library* requires semigroupoids >=5 && < 5.4 and the snapshot contains semigroupoids-6.0.0.1
+        - sv < 0 # tried sv-1.4.0.1, but its *library* requires the disabled package: hw-dsv
+        - sv < 0 # tried sv-1.4.0.1, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - sv-cassava < 0 # tried sv-cassava-0.3, but its *library* requires attoparsec >=0.12.1.4 && < 0.14 and the snapshot contains attoparsec-0.14.4
+        - sv-cassava < 0 # tried sv-cassava-0.3, but its *library* requires bytestring >=0.9.1.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - sv-cassava < 0 # tried sv-cassava-0.3, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - sv-core < 0 # tried sv-core-0.5, but its *library* requires attoparsec >=0.12.1.4 && < 0.14 and the snapshot contains attoparsec-0.14.4
+        - sv-core < 0 # tried sv-core-0.5, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.18.1.0
+        - sv-core < 0 # tried sv-core-0.5, but its *library* requires bifunctors >=5.1 && < 5.6 and the snapshot contains bifunctors-5.6.1
+        - sv-core < 0 # tried sv-core-0.5, but its *library* requires bytestring >=0.9.1.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - sv-core < 0 # tried sv-core-0.5, but its *library* requires lens >=4 && < 4.20 and the snapshot contains lens-5.2.3
+        - sv-core < 0 # tried sv-core-0.5, but its *library* requires mtl >=2.0.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - sv-core < 0 # tried sv-core-0.5, but its *library* requires profunctors >=5.2.1 && < 5.6 and the snapshot contains profunctors-5.6.2
+        - sv-core < 0 # tried sv-core-0.5, but its *library* requires semigroupoids >=5 && < 5.4 and the snapshot contains semigroupoids-6.0.0.1
+        - sv-core < 0 # tried sv-core-0.5, but its *library* requires semigroups >=0.18 && < 0.20 and the snapshot contains semigroups-0.20
+        - sv-core < 0 # tried sv-core-0.5, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - sv-core < 0 # tried sv-core-0.5, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - sv-core < 0 # tried sv-core-0.5, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires aeson >=1.0 && < 2.0 and the snapshot contains aeson-2.1.2.1
+        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires bytestring >=0.10.0 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires containers >=0.5.0.0 && < 0.6 and the snapshot contains containers-0.6.7
+        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires http-api-data >=0.3.4 && < 0.4 and the snapshot contains http-api-data-0.5.1
+        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.15
+        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires http-media >=0.4 && < 0.8 and the snapshot contains http-media-0.8.1.1
+        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires katip >=0.4 && < 0.6 and the snapshot contains katip-0.8.8.0
+        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires network >=2.6.2 && < 2.8 and the snapshot contains network-3.1.4.0
+        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
+        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires time >=1.5 && < 1.10 and the snapshot contains time-1.12.2
+        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires vector >=0.10.9 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - sweet-egison < 0 # tried sweet-egison-0.1.1.3, but its *library* requires logict ^>=0.7.0 and the snapshot contains logict-0.8.1.0
+        - syb-with-class < 0 # tried syb-with-class-0.6.1.14, but its *library* requires template-haskell >=2.4 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
+        - sydtest-persistent-postgresql < 0 # tried sydtest-persistent-postgresql-0.2.0.3, but its *library* requires the disabled package: tmp-postgres
+        - taffybar < 0 # tried taffybar-4.0.1, but its *library* requires scotty >=0.11 && < 0.13 and the snapshot contains scotty-0.20.1
+        - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* requires containers >=0.4 && < 0.6 and the snapshot contains containers-0.6.7
+        - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* requires tasty >=0.11.2 && < 1.2 and the snapshot contains tasty-1.4.3
+        - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* requires time >=1.5 && < 1.9 and the snapshot contains time-1.12.2
+        - tasty-test-reporter < 0 # tried tasty-test-reporter-0.1.1.4, but its *library* requires ansi-terminal >=0.8 && < 0.12 and the snapshot contains ansi-terminal-1.0
+        - tasty-test-reporter < 0 # tried tasty-test-reporter-0.1.1.4, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - tasty-test-reporter < 0 # tried tasty-test-reporter-0.1.1.4, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - tcp-streams-openssl < 0 # tried tcp-streams-openssl-1.0.1.0, but its *library* requires network >=2.3 && < 3.0 and the snapshot contains network-3.1.4.0
+        - tcp-streams-openssl < 0 # tried tcp-streams-openssl-1.0.1.0, but its *library* requires the disabled package: tcp-streams
+        - telegram-bot-api < 0 # tried telegram-bot-api-6.7.1, but its *library* requires the disabled package: cron
+        - telegram-bot-simple < 0 # tried telegram-bot-simple-0.12, but its *library* requires the disabled package: cron
+        - termcolor < 0 # tried termcolor-0.2.0.0, but its *executable* requires the disabled package: cli
+        - test-fixture < 0 # tried test-fixture-0.5.1.0, but its *library* requires template-haskell >=2.10 && < 2.13 and the snapshot contains template-haskell-2.20.0.0
+        - test-framework-th < 0 # tried test-framework-th-0.2.4, but its *library* requires the disabled package: language-haskell-extract
+        - text-all < 0 # tried text-all-0.4.2, but its *library* requires text ==1.2.3.* and the snapshot contains text-2.0.2
+        - text-all < 0 # tried text-all-0.4.2, but its *library* requires text-format ==0.3.1.* and the snapshot contains text-format-0.3.2.1
+        - text-generic-pretty < 0 # tried text-generic-pretty-1.2.1, but its *library* requires wl-pprint-text < 1.2 and the snapshot contains wl-pprint-text-1.2.0.2
+        - th-to-exp < 0 # tried th-to-exp-0.0.1.1, but its *library* requires template-haskell >=2.11.0.0 && < 2.13 and the snapshot contains template-haskell-2.20.0.0
+        - through-text < 0 # tried through-text-0.1.0.0, but its *library* requires base >=4.3 && < 4.17 and the snapshot contains base-4.18.1.0
+        - thumbnail-plus < 0 # tried thumbnail-plus-1.0.5, but its *library* requires either < 5 and the snapshot contains either-5.0.2
+        - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires tls >=1.3 && < 1.6 and the snapshot contains tls-1.8.0
+        - tonalude < 0 # tried tonalude-0.2.0.0, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.18.1.0
+        - tonaparser < 0 # tried tonaparser-0.2.0.0, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.18.1.0
+        - tonatona < 0 # tried tonatona-0.2.0.0, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.18.1.0
+        - tonatona-logger < 0 # tried tonatona-logger-0.3.0.0, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.18.1.0
+        - tonatona-persistent-postgresql < 0 # tried tonatona-persistent-postgresql-0.2.0.0, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.18.1.0
+        - tonatona-persistent-sqlite < 0 # tried tonatona-persistent-sqlite-0.2.0.0, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.18.1.0
+        - tonatona-servant < 0 # tried tonatona-servant-0.2.0.0, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.18.1.0
+        - tonatona-servant < 0 # tried tonatona-servant-0.2.0.0, but its *library* requires servant >=0.18 && < 0.20 and the snapshot contains servant-0.20.1
+        - tonatona-servant < 0 # tried tonatona-servant-0.2.0.0, but its *library* requires servant-server >=0.18 && < 0.20 and the snapshot contains servant-server-0.20
+        - tracing-control < 0 # tried tracing-control-0.0.7.3, but its *library* requires the disabled package: stm-lifted
+        - transformers-bifunctors < 0 # tried transformers-bifunctors-0.1, but its *library* requires mmorph >=1.0 && < 1.2 and the snapshot contains mmorph-1.2.0
+        - transformers-bifunctors < 0 # tried transformers-bifunctors-0.1, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - transformers-fix < 0 # tried transformers-fix-1.0, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* requires base >=4.8 && < 4.13 and the snapshot contains base-4.18.1.0
+        - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* requires writer-cps-transformers ==0.1.1.4 and the snapshot contains writer-cps-transformers-0.5.6.1
+        - transient-universe < 0 # tried transient-universe-0.6.0.1, but its *library* requires network >=2.8.0.0 && < 3.0.0.0 and the snapshot contains network-3.1.4.0
+        - transient-universe < 0 # tried transient-universe-0.6.0.1, but its *library* requires the disabled package: TCache
+        - transient-universe < 0 # tried transient-universe-0.6.0.1, but its *library* requires the disabled package: transient
+        - tries < 0 # tried tries-0.0.6.1, but its *library* requires the disabled package: rose-trees
+        - triplesec < 0 # tried triplesec-0.2.2.1, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
+        - true-name < 0 # tried true-name-0.1.0.3, but its *library* requires template-haskell >=2.7 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
+        - ttl-hashtables < 0 # tried ttl-hashtables-1.4.1.0, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.3.0
+        - ttl-hashtables < 0 # tried ttl-hashtables-1.4.1.0, but its *library* requires hashtables >=1.2 && < 1.3 and the snapshot contains hashtables-1.3.1
+        - ttl-hashtables < 0 # tried ttl-hashtables-1.4.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - ttl-hashtables < 0 # tried ttl-hashtables-1.4.1.0, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - type-combinators-singletons < 0 # tried type-combinators-singletons-0.2.1.0, but its *library* requires the disabled package: type-combinators
+        - type-errors-pretty < 0 # tried type-errors-pretty-0.0.1.2, but its *library* requires base >=4.10.1.0 && < 4.16 and the snapshot contains base-4.18.1.0
+        - type-operators < 0 # tried type-operators-0.2.0.0, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.18.1.0
+        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires aeson >=1.2 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires attoparsec >=0.13.2.2 && < 0.14 and the snapshot contains attoparsec-0.14.4
+        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires base >=4.11.0.0 && < 4.13 and the snapshot contains base-4.18.1.0
+        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires cryptonite >=0.25 && < 0.27 and the snapshot contains cryptonite-0.30
+        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires http-api-data >=0.3.8.1 && < 0.5 and the snapshot contains http-api-data-0.5.1
+        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires parser-combinators >=1.0.0 && < 1.3 and the snapshot contains parser-combinators-1.3.0
+        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires text >=0.11 && < 1.2.3.0 || >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
+        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires time >=1.8.0.2 && < 1.10 and the snapshot contains time-1.12.2
+        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires aeson >=1.2 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires base >=4.11.0.0 && < 4.13 and the snapshot contains base-4.18.1.0
+        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires base64-bytestring >=1.0.0.1 && < 1.1 and the snapshot contains base64-bytestring-1.2.1.0
+        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires text >=0.11 && < 1.2.3.0 || >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
+        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires time >=1.8.0.2 && < 1.10 and the snapshot contains time-1.12.2
+        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires timerep >=2.0.0.2 && < 2.1 and the snapshot contains timerep-2.1.0.0
+        - unbound-generics < 0 # tried unbound-generics-0.4.3, but its *library* requires ansi-wl-pprint >=0.6.7.2 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
+        - unfoldable < 0 # tried unfoldable-1.0.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - unfoldable-restricted < 0 # tried unfoldable-restricted-0.0.3, but its *library* requires the disabled package: unfoldable
+        - unification-fd < 0 # tried unification-fd-0.11.2, but its *library* requires logict >=0.4 && < 0.8.1 and the snapshot contains logict-0.8.1.0
+        - union < 0 # tried union-0.1.2, but its *library* requires base >=4.9 && < 4.18 and the snapshot contains base-4.18.1.0
+        - union-find < 0 # tried union-find-0.2, but its *library* requires base >=4.4 && < 4.17 and the snapshot contains base-4.18.1.0
+        - uniprot-kb < 0 # tried uniprot-kb-0.1.2.0, but its *library* requires attoparsec >=0.10 && < 0.14 and the snapshot contains attoparsec-0.14.4
+        - uniprot-kb < 0 # tried uniprot-kb-0.1.2.0, but its *library* requires text >=0.2 && < 1.3 and the snapshot contains text-2.0.2
+        - unliftio-pool < 0 # tried unliftio-pool-0.4.2.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - urbit-hob < 0 # tried urbit-hob-0.3.3, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
+        - uri-templater < 0 # tried uri-templater-0.3.1.0, but its *library* requires trifecta >=1.6 && < 1.8 and the snapshot contains trifecta-2.1.3
+        - userid < 0 # tried userid-0.1.3.7, but its *library* requires aeson >=0.9 && < 2.1 and the snapshot contains aeson-2.1.2.1
+        - userid < 0 # tried userid-0.1.3.7, but its *library* requires base >=4.6 && < 4.17 and the snapshot contains base-4.18.1.0
+        - userid < 0 # tried userid-0.1.3.7, but its *library* requires the disabled package: web-routes
+        - utf8-conversions < 0 # tried utf8-conversions-0.1.0.4, but its *library* requires bytestring >=0.10.4 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - utf8-conversions < 0 # tried utf8-conversions-0.1.0.4, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - utf8-conversions < 0 # tried utf8-conversions-0.1.0.4, but its *library* requires text-short >=0.1.1 && < 0.1.4 and the snapshot contains text-short-0.1.5
+        - vado < 0 # tried vado-0.0.14, but its *library* requires base >=4.0.0.0 && < 4.17 and the snapshot contains base-4.18.1.0
+        - variable-media-field < 0 # tried variable-media-field-0.1.0.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - variable-media-field-dhall < 0 # tried variable-media-field-dhall-0.1.0.0, but its *library* requires the disabled package: variable-media-field
+        - variable-media-field-optics < 0 # tried variable-media-field-optics-0.1.0.0, but its *library* requires the disabled package: variable-media-field
+        - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* requires base >=4.0.0.0 && < 4.11 and the snapshot contains base-4.18.1.0
+        - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* requires containers >=0.5.5.1 && < 0.6 and the snapshot contains containers-0.6.7
+        - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* requires mtl >=2.0.1.0 && < 2.3 and the snapshot contains mtl-2.3.1
+        - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* requires text >=0.11.1.5 && < 1.3 and the snapshot contains text-2.0.2
+        - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.18.1.0
+        - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires primitive >=0.6.4 && < 0.8 and the snapshot contains primitive-0.8.0.0
+        - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires semigroupoids >=5.3 && < 5.4 and the snapshot contains semigroupoids-6.0.0.1
+        - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires template-haskell >=2.12 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
+        - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires vector >=0.12 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - vector-fftw < 0 # tried vector-fftw-0.1.4.0, but its *library* requires base >=4.3 && < 4.15 and the snapshot contains base-4.18.1.0
+        - vector-fftw < 0 # tried vector-fftw-0.1.4.0, but its *library* requires primitive >=0.6 && < 0.8 and the snapshot contains primitive-0.8.0.0
+        - vector-fftw < 0 # tried vector-fftw-0.1.4.0, but its *library* requires vector >=0.9 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - vectortiles < 0 # tried vectortiles-1.5.1, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
+        - vectortiles < 0 # tried vectortiles-1.5.1, but its *library* requires the disabled package: protocol-buffers
+        - vectortiles < 0 # tried vectortiles-1.5.1, but its *library* requires transformers ^>=0.5 and the snapshot contains transformers-0.6.1.0
+        - vectortiles < 0 # tried vectortiles-1.5.1, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - vformat-aeson < 0 # tried vformat-aeson-0.1.0.1, but its *library* requires aeson >=1.2 && < 2.0 and the snapshot contains aeson-2.1.2.1
+        - vformat-aeson < 0 # tried vformat-aeson-0.1.0.1, but its *library* requires text >=1.2 && < 2.0 and the snapshot contains text-2.0.2
+        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires base >=4.9 && < 4.15 and the snapshot contains base-4.18.1.0
+        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires brick >0.26.1 && < 0.54 and the snapshot contains brick-2.1.1
+        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires lens >=4.14 && < 4.20 and the snapshot contains lens-5.2.3
+        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires text >=1.2.2.0 && < 1.3 and the snapshot contains text-2.0.2
+        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires vector >=0.10.12.3 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires vector-algorithms >=0.6.0.4 && < 0.9 and the snapshot contains vector-algorithms-0.9.0.1
+        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires vty >=5.13 && < 5.29 and the snapshot contains vty-6.1
+        - wai-middleware-crowd < 0 # tried wai-middleware-crowd-0.1.4.2, but its *executable* requires optparse-applicative >=0.11 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
+        - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires aeson >=1.0 && < 1.4 and the snapshot contains aeson-2.1.2.1
+        - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.15
+        - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
+        - wai-routing < 0 # tried wai-routing-0.13.0, but its *library* requires the disabled package: wai-predicates
+        - wai-routing < 0 # tried wai-routing-0.13.0, but its *library* requires the disabled package: wai-route
+        - wavefront < 0 # tried wavefront-0.7.1.5, but its *library* requires base >=4.8 && < 4.18 and the snapshot contains base-4.18.1.0
+        - web-plugins < 0 # tried web-plugins-0.4.1, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - web-plugins < 0 # tried web-plugins-0.4.1, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
+        - web-routes-boomerang < 0 # tried web-routes-boomerang-0.28.4.4, but its *library* requires the disabled package: web-routes
+        - web-routes-happstack < 0 # tried web-routes-happstack-0.23.12.3, but its *library* requires the disabled package: web-routes
+        - web-routes-hsp < 0 # tried web-routes-hsp-0.24.6.2, but its *library* requires the disabled package: hsp
+        - web-routes-hsp < 0 # tried web-routes-hsp-0.24.6.2, but its *library* requires the disabled package: web-routes
+        - web-routes-th < 0 # tried web-routes-th-0.22.8.1, but its *library* requires template-haskell >=2.11 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - web-routes-th < 0 # tried web-routes-th-0.22.8.1, but its *library* requires the disabled package: web-routes
+        - web-routes-wai < 0 # tried web-routes-wai-0.24.3.2, but its *library* requires the disabled package: web-routes
+        - web3 < 0 # tried web3-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.1.0
+        - web3-bignum < 0 # tried web3-bignum-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.1.0
+        - web3-bignum < 0 # tried web3-bignum-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
+        - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.1.0
+        - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires cryptonite >0.22 && < 0.30 and the snapshot contains cryptonite-0.30
+        - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
+        - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires vector >0.12 && < 0.13 and the snapshot contains vector-0.13.1.0
+        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires OneTuple >0.2 && < 0.3 and the snapshot contains OneTuple-0.4.1.1
+        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.1.0
+        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
+        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires microlens-aeson >2.2 && < 2.4 and the snapshot contains microlens-aeson-2.5.1
+        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires mtl >2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
+        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires transformers >0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires vinyl >0.5 && < 0.14 and the snapshot contains vinyl-0.14.3
+        - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.1.0
+        - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires cryptonite >0.22 && < 0.30 and the snapshot contains cryptonite-0.30
+        - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
+        - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires mtl >2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.1.0
+        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires http-client >0.5 && < 0.7 and the snapshot contains http-client-0.7.15
+        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires mtl >2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires transformers >0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires OneTuple >0.2 && < 0.3 and the snapshot contains OneTuple-0.4.1.1
+        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.1.0
+        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
+        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
+        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - webby < 0 # tried webby-1.1.1, but its *library* requires formatting >=6.3.7 && < 7.2 and the snapshot contains formatting-7.2.0
+        - webby < 0 # tried webby-1.1.1, but its *library* requires resourcet ==1.2.* and the snapshot contains resourcet-1.3.0
+        - webdriver-angular < 0 # tried webdriver-angular-0.1.11, but its *library* requires language-javascript >=0.6 && < 0.7 and the snapshot contains language-javascript-0.7.1.0
+        - webdriver-angular < 0 # tried webdriver-angular-0.1.11, but its *library* requires webdriver >=0.6 && < 0.9 and the snapshot contains webdriver-0.12.0.0
+        - wikicfp-scraper < 0 # tried wikicfp-scraper-0.1.0.13, but its *library* requires text >=0.11.3.1 && < 1.3 and the snapshot contains text-2.0.2
+        - wikicfp-scraper < 0 # tried wikicfp-scraper-0.1.0.13, but its *library* requires time >=1.4.0 && < 1.12 and the snapshot contains time-1.12.2
+        - wild-bind < 0 # tried wild-bind-0.1.2.9, but its *library* requires base >=4.6 && < 4.17 and the snapshot contains base-4.18.1.0
+        - wild-bind < 0 # tried wild-bind-0.1.2.9, but its *library* requires text >=1.2.0 && < 1.3 and the snapshot contains text-2.0.2
+        - wild-bind < 0 # tried wild-bind-0.1.2.9, but its *library* requires transformers >=0.3.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - wild-bind-x11 < 0 # tried wild-bind-x11-0.2.0.15, but its *library* requires base >=4.6 && < 4.17 and the snapshot contains base-4.18.1.0
+        - wild-bind-x11 < 0 # tried wild-bind-x11-0.2.0.15, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - wild-bind-x11 < 0 # tried wild-bind-x11-0.2.0.15, but its *library* requires text >=1.2.0 && < 1.3 and the snapshot contains text-2.0.2
+        - wild-bind-x11 < 0 # tried wild-bind-x11-0.2.0.15, but its *library* requires transformers >=0.3.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - wire-streams < 0 # tried wire-streams-0.1.1.0, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.5.2
+        - wl-pprint-console < 0 # tried wl-pprint-console-0.1.0.2, but its *library* requires bytestring >=0.10.2 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - wl-pprint-console < 0 # tried wl-pprint-console-0.1.0.2, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
+        - wl-pprint-extras < 0 # tried wl-pprint-extras-3.5.0.5, but its *library* requires containers >=0.4 && < 0.6 and the snapshot contains containers-0.6.7
+        - wl-pprint-extras < 0 # tried wl-pprint-extras-3.5.0.5, but its *library* requires semigroupoids >=3 && < 6 and the snapshot contains semigroupoids-6.0.0.1
+        - wl-pprint-extras < 0 # tried wl-pprint-extras-3.5.0.5, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
+        - wl-pprint-terminfo < 0 # tried wl-pprint-terminfo-3.7.1.4, but its *library* requires bytestring >=0.9.1 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - wl-pprint-terminfo < 0 # tried wl-pprint-terminfo-3.7.1.4, but its *library* requires containers >=0.4 && < 0.6 and the snapshot contains containers-0.6.7
+        - wl-pprint-terminfo < 0 # tried wl-pprint-terminfo-3.7.1.4, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
+        - wl-pprint-terminfo < 0 # tried wl-pprint-terminfo-3.7.1.4, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - wrecker < 0 # tried wrecker-1.3.2.0, but its *library* requires the disabled package: ansigraph
+        - wrecker < 0 # tried wrecker-1.3.2.0, but its *library* requires the disabled package: clock-extras
+        - wrecker < 0 # tried wrecker-1.3.2.0, but its *library* requires the disabled package: connection
+        - wrecker < 0 # tried wrecker-1.3.2.0, but its *library* requires the disabled package: next-ref
+        - writer-cps-exceptions < 0 # tried writer-cps-exceptions-0.1.0.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - writer-cps-full < 0 # tried writer-cps-full-0.1.0.0, but its *library* requires the disabled package: writer-cps-morph
+        - writer-cps-lens < 0 # tried writer-cps-lens-0.1.0.1, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2.3
+        - writer-cps-lens < 0 # tried writer-cps-lens-0.1.0.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - writer-cps-mtl < 0 # tried writer-cps-mtl-0.1.1.6, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
+        - writer-cps-mtl < 0 # tried writer-cps-mtl-0.1.1.6, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - xdg-desktop-entry < 0 # tried xdg-desktop-entry-0.1.1.1, but its *library* requires the disabled package: ConfigFile
+        - xml-parser < 0 # tried xml-parser-0.1.1.1, but its *library* requires transformers ^>=0.5 and the snapshot contains transformers-0.6.1.0
+        - xmonad-contrib < 0 # tried xmonad-contrib-0.17.1, but its *library* requires mtl >=1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - xmonad-extras < 0 # tried xmonad-extras-0.17.0, but its *library* requires the disabled package: libmpd
+        - xmonad-extras < 0 # tried xmonad-extras-0.17.0, but its *library* requires the disabled package: xmonad-contrib
+        - yeshql < 0 # tried yeshql-4.2.0.0, but its *library* requires the disabled package: yeshql-hdbc
+        - yeshql < 0 # tried yeshql-4.2.0.0, but its *library* requires yeshql-core ==4.1.1.2 and the snapshot contains yeshql-core-4.2.0.0
+        - yesod-alerts < 0 # tried yesod-alerts-0.1.3.0, but its *library* requires text >=0.11 && < 2.0 and the snapshot contains text-2.0.2
+        - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires persistent >=2.1 && < 2.8 and the snapshot contains persistent-2.14.6.0
+        - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires yesod-auth >=1.4.18 && < 1.5 and the snapshot contains yesod-auth-1.6.11.2
+        - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires yesod-core >=1.4 && < 1.5 and the snapshot contains yesod-core-1.6.25.1
+        - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires yesod-form >=1.4 && < 1.5 and the snapshot contains yesod-form-1.7.6
+        - yesod-form-richtext < 0 # tried yesod-form-richtext-0.1.0.2, but its *library* requires yesod-core >=1.4 && < 1.5 and the snapshot contains yesod-core-1.6.25.1
+        - yesod-form-richtext < 0 # tried yesod-form-richtext-0.1.0.2, but its *library* requires yesod-form >=1.4.4.1 && < 1.5 and the snapshot contains yesod-form-1.7.6
+        - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *executable* requires yesod >=1.2 && < 1.5 and the snapshot contains yesod-1.6.2.1
+        - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* requires language-javascript >=0.6 && < 0.7 and the snapshot contains language-javascript-0.7.1.0
+        - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* requires yesod-core >=1.2 && < 1.5 and the snapshot contains yesod-core-1.6.25.1
+        - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* requires yesod-static >=1.2.1 && < 1.6 and the snapshot contains yesod-static-1.6.1.0
+        - yesod-text-markdown < 0 # tried yesod-text-markdown-0.1.10, but its *library* requires aeson >=0.7 && < 2.0 and the snapshot contains aeson-2.1.2.1
+        - yesod-text-markdown < 0 # tried yesod-text-markdown-0.1.10, but its *library* requires text >=0.11 && < 2.0 and the snapshot contains text-2.0.2
+        - zasni-gerna < 0 # tried zasni-gerna-0.0.7.1, but its *library* requires the disabled package: papillon
+        - zero < 0 # tried zero-0.1.5, but its *library* requires semigroups >=0.16 && < 0.20 and the snapshot contains semigroups-0.20
+        - zio < 0 # tried zio-0.1.0.2, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - zio < 0 # tried zio-0.1.0.2, but its *library* requires the disabled package: unexceptionalio-trans
+        - zio < 0 # tried zio-0.1.0.2, but its *library* requires transformers >=0.5.6 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - zipper-extra < 0 # tried zipper-extra-0.1.3.2, but its *library* requires the disabled package: comonad-extras
+        - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* requires base-compat ==0.9.* and the snapshot contains base-compat-0.13.1
+        - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* requires servant >=0.9 && < 0.12 and the snapshot contains servant-0.20.1
+        - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* requires servant-client >=0.9 && < 0.12 and the snapshot contains servant-client-0.20
+        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires aeson >=0.7 && < 1.3 and the snapshot contains aeson-2.1.2.1
+        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires base-compat ==0.9.* and the snapshot contains base-compat-0.13.1
+        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.5.2
+        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires http-api-data ==0.3.* and the snapshot contains http-api-data-0.5.1
+        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires servant >=0.9 && < 0.12 and the snapshot contains servant-0.20.1
+        - zlib-lens < 0 # tried zlib-lens-0.1.2.1, but its *library* requires bytestring >=0.9.1.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - zm < 0 # tried zm-0.3.2, but its *library* requires bytestring >=0.10.6.0 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - zm < 0 # tried zm-0.3.2, but its *library* requires containers ==0.5.* and the snapshot contains containers-0.6.7
+        - zm < 0 # tried zm-0.3.2, but its *library* requires flat ==0.3.* and the snapshot contains flat-0.6
+        - zm < 0 # tried zm-0.3.2, but its *library* requires model >=0.4.4 && < 0.5 and the snapshot contains model-0.5
+        - zm < 0 # tried zm-0.3.2, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - ztail < 0 # tried ztail-1.2.0.3, but its *executable* requires time >=1.5 && < 1.12 and the snapshot contains time-1.12.2
+        - ztail < 0 # tried ztail-1.2.0.3, but its *executable* requires unix ==2.7.* and the snapshot contains unix-2.8.1.0
+        - zydiskell < 0 # tried zydiskell-0.2.0.0, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.1.0
+        - zydiskell < 0 # tried zydiskell-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+        - zydiskell < 0 # tried zydiskell-0.2.0.0, but its *library* requires storable-record >=0.0.5 && < 0.0.6 and the snapshot contains storable-record-0.0.7
+    # End of Library and exe bounds failures
+
+    "Stackage upper bounds":
+        # https://github.com/commercialhaskell/stackage/issues/7031
+        - aeson ^>= 2.1.2.1 && <2.2.0
+        - attoparsec-aeson ^>= 2.1.0.0 && <2.2
+
+        # https://github.com/commercialhaskell/stackage/issues/7055
+        - dependent-sum-template ^>= 0.1.1.1 && <0.1.2
+
+        # https://github.com/commercialhaskell/stackage/issues/7074
+        - th-abstraction ^>= 0.5.0.0 && <0.6.0.0
+
+        # https://github.com/commercialhaskell/stackage/issues/7205
+        - megaparsec ^>= 9.5.0 && <9.6
+        - megaparsec-tests ^>= 9.5.0 && <9.6
+
+        # https://github.com/commercialhaskell/stackage/issues/7106
+        - tls ^>= 1.8.0 && <1.9
+
+        # https://github.com/commercialhaskell/stackage/issues/7111
+        - tasty ^>= 1.4.3 && <1.5
+        - tasty-quickcheck ^>= 0.10.2 && <0.10.3
+
+        # https://github.com/commercialhaskell/stackage/issues/7124
+        - mpi-hs ^>= 0.7.2.0 && <0.7.3
+
+        # https://github.com/commercialhaskell/stackage/issues/7129
+        - lpeg ^>= 1.0.4 && <1.1
+
+        # https://github.com/commercialhaskell/stackage/issues/7144
+        # ghc9.8 - need base >= 4.19
+        - eliminators ^>= 0.9.3 && <0.9.4
+        - fourmolu ^>= 0.14.0.0 && <0.14.1.0
+        - ghc-lib ^>= 9.6.3.20231121 && <9.8
+        - ghc-lib-parser ^>= 9.6.3.20231121 && <9.8
+        - ghc-lib-parser-ex ^>= 9.6.0.2 && <9.8
+        - ormolu ^>= 0.7.2.0 && <0.7.3.0
+        - singletons-base ^>= 3.2 && <3.3
+        - singletons-th ^>= 3.2 && <3.3
+        - th-desugar ^>= 1.15 && <1.16
+
+        # https://github.com/commercialhaskell/stackage/issues/7159
+        - Diff ^>= 0.4.1 && <0.5
+
+        # https://github.com/commercialhaskell/stackage/issues/7178
+        - cassava-megaparsec ^>= 2.0.4 && <2.1
+    # end of Stackage upper bounds
+# end of packages
+
+# Package flags are applied to individual packages, and override the values of
+# global-flags
+package-flags:
+    QuickCheck:
+        old-random: false
+    pathtype:
+        old-time: false
+
+    bz2:
+        with-bzlib: false   # Exclude bzlib from benchmarks to avoid unnecessary dependencies.
+
+    mersenne-random-pure64:
+        small_base: false
+
+    cloud-haskell:
+        tcp: true
+        simplelocalnet: true
+        p2p: true
+
+    curl:
+        new-base: true
+
+    hpio:
+        test-hlint: false
+
+    idris:
+        ffi: true
+
+    hxt:
+        network-uri: true
+    hxt-http:
+        network-uri: true
+    hxt-relaxng:
+        network-uri: true
+
+    text:
+        integer-simple: false
+
+    tar:
+        old-time: false
+
+    time-locale-compat:
+        old-locale: false
+
+    HsOpenSSL:
+        fast-bignum: false
+
+    cabal-rpm:
+        old-locale: false
+
+    NineP:
+        bytestring-in-base: false
+
+    nix-paths:
+        allow-relative-paths: true
+
+    fay:
+        test: true
+
+    reedsolomon:
+        llvm: false
+
+    functor-classes-compat:
+        containers: true
+
+    alerta:
+        servant-client-core: false
+
+    cabal-install:
+        # https://github.com/haskell/cabal/issues/9054
+        native-dns: false
+
+    greskell:
+        server-test: false
+
+    windns:
+        allow-non-windows: true
+
+    hsdev:
+        docs: false
+
+    bson:
+        _old-network: false
+
+    mongoDB:
+        _old-network: false
+
+    sdl2:
+      recent-ish: false
+
+    formatting:
+      no-double-conversion: true
+
+    hackage-security:
+      Cabal-syntax: true
+
+    aws-sns-verify:
+      development: true
+
+    optics-operators:
+      build-readme: false
+
+    # optparse-applicative dependencies depend on the version
+    bm:
+      optparse-applicative_ge_0_18: true
+    horizontal-rule:
+      optparse-applicative_ge_0_18: true
+    literatex:
+      optparse-applicative_ge_0_18: true
+    phatsort:
+      optparse-applicative_ge_0_18: true
+    redact:
+      optparse-applicative_ge_0_18: true
+# end of package-flags
+
+# Special configure options for individual packages
+
+# This used to be used for extra-include-dirs and extra-lib-dirs
+# Instead, we set this in the Docker image itself
+configure-args: {}
+# end of configure-args
+
+
+# Used for packages that cannot be built on Linux
+skipped-builds:
+    - hfsevents
+    - lzma-clib
+    - Win32
+    - Win32-notify
+    - windns
+
+# end of skipped-builds
+
+
+# By skipping a test suite, we do not pull in the build dependencies
+# Packages should only be added here if required by `stackage-curator check'
+# or if Setup fails because of missing foreign libraries.
+# Otherwise place them in expected-test-failures.
+skipped-tests:
+    # Missing foreign libraries
+    - symengine
+    - hasql-interpolate # https://github.com/commercialhaskell/stackage/issues/6841
+
+    # Timeouts
+    # These tests sometimes take too long and hit the stackage build
+    # servers time limit so these shouldn't be removed from
+    # skipped-tests unless we know a fix has been released.
+    - accelerate-fourier
+    - binary-search # Never finishes https://github.com/nushio3/binary-search/issues/2
+    - blank-canvas # Never finishes https://github.com/ku-fpg/blank-canvas/issues/73
+    - cabal-helper
+    - enum-text # https://github.com/commercialhaskell/stackage/issues/6794
+    - ghc-exactprint # flaky fails with 'executable not found' & and runs around 15 minutes (so put here instead of expected-test-failures)
+    - hpc-codecov # timeouts? https://github.com/commercialhaskell/stackage/issues/5976
+    - ihaskell # Never finishes https://github.com/IHaskell/IHaskell/issues/1413
+    - jsaddle # Never finishes without framebuffer https://github.com/ghcjs/jsaddle/issues/9
+    - json-rpc  # flaky
+    - network-attoparsec
+    - port-utils
+    - punycode
+    - sbv # takes more than 4 hours for a single test suite
+    - unagi-chan
+    - zeromq4-patterns
+
+    # Wontfix. The maintainer doesn't want to keep test dependencies
+    # up to date or be notified about it, or doesn't want stackage to
+    # run the tests.
+    # Only re-enable if requested.
+    ## @hvr https://github.com/fpco/stackage/issues/2538#issuecomment-304458844
+    - lzma
+    - token-bucket
+    - uuid
+    - uuid-types
+    # @nikita-volkov https://github.com/fpco/stackage/issues/2538#issuecomment-305129396
+    - base-prelude
+    - bytestring-strict-builder
+    - bytestring-tree-builder
+    - cases
+    - focus
+    - hasql
+    - hasql-pool
+    - list-t
+    - mtl-prelude
+    - neat-interpolation
+    - partial-handler
+    - postgresql-binary
+    - refined
+    - slave-thread
+    - stm-containers
+    - text-builder
+    # @ivan-m https://github.com/fpco/stackage/issues/2538#issuecomment-307290070
+    - fgl
+    - fgl-arbitrary
+    - graphviz
+    - wl-pprint-text
+    # @phadej
+    - aeson-extra
+    - base64-bytestring-type
+    - binary-orphans
+    - edit-distance
+    - fin
+    - http-api-data
+    - integer-logarithms
+    - postgresql-simple-url
+    - range-set-list
+    - time-parsers
+    - time-parsers
+    - universe-base
+    - vec
+    # @jsynacek
+    - hpqtypes # needs a running postgres database
+    - hpqtypes-extras # needs a running postgres database
+
+    # norfairking
+    - afksautodocodec # runs doctest
+    - sydtest-amqp # runs rabbitmq
+    - sydtest-rabbitmq # runs rabbitmq
+    - sydtest-hedis # runs redis
+    - sydtest-mongo # runs mongo
+    - sydtest-persistent-sqlite # runs sqlite
+    - sydtest-persistent-postgresql # runs postgres
+    - sydtest-webdriver # runs chromium
+    - sydtest-webdriver-screenshot # runs chromium
+    - sydtest-webdriver-yesod # runs chromium
+
+    - captcha-core
+    - captcha-2captcha
+    - captcha-capmonster
+
+    # @thielema
+    - glpk-headers
+
+    # Uses Cabal's "library internal" stanza feature
+    - s3-signer
+
+    # Due to cycles, which are actually just limitations in Stack right now.
+    - HUnit
+    - Agda
+    - aeson
+    - indexed-traversable-instances
+    - semialign
+    - attoparsec
+    - base-orphans # via hspec
+    - bifunctors # via hspec
+    - call-stack
+    - case-insensitive
+    - clock
+    - criterion
+    - criterion-measurement
+    - distributive # via hspec
+    - doctest # via hspec
+    - foldable1-classes-compat
+    - foundation
+    - hspec
+    - hspec-discover # via logging-facade/mockery
+    - http-streams
+    - js-flot
+    - js-jquery
+    - microstache
+    - nanospec
+    - nothunks
+    - optparse-applicative # via QuickCheck
+    - primitive
+    - random
+    - scientific
+    - split
+    - splitmix
+    - statistics
+    - syb
+    - tasty-expected-failure # via tasty-hedgehog
+    - vector # doctest
+    - vector-binary-instances
+
+    # TODO
+    - rpmbuild-order
+
+    # Revision to package caused it to require bounds and break
+    - htoml  # https://github.com/commercialhaskell/stackage/issues/6239
+
+    # See "Large scale enabling/disabling of packages" in CURATORS.md for how to manage this section.
+    #
+    # Test bounds issues
+    - BiobaseNewick # tried BiobaseNewick-0.0.0.2, but its *test-suite* requires the disabled package: test-framework-th
+    - ENIG # tried ENIG-0.0.1.0, but its *test-suite* requires the disabled package: test-framework-th
+    - Frames # tried Frames-0.7.4.2, but its *test-suite* requires the disabled package: tomland
+    - Frames # tried Frames-0.7.4.2, but its *test-suite* requires the disabled package: validation-selective
+    - IPv6DB # tried IPv6DB-0.3.3, but its *test-suite* requires hspec >=2.1.10 && < 2.8 and the snapshot contains hspec-2.11.7
+    - JuicyPixels-blurhash # tried JuicyPixels-blurhash-0.1.0.3, but its *test-suite* requires doctest >=0.16.2 && < 0.20 and the snapshot contains doctest-0.22.2
+    - JuicyPixels-blurhash # tried JuicyPixels-blurhash-0.1.0.3, but its *test-suite* requires hedgehog >=1.0.2 && < 1.2 and the snapshot contains hedgehog-1.4
+    - JuicyPixels-blurhash # tried JuicyPixels-blurhash-0.1.0.3, but its *test-suite* requires tasty-discover >=4.2.1 && < 4.3 and the snapshot contains tasty-discover-5.0.0
+    - JuicyPixels-blurhash # tried JuicyPixels-blurhash-0.1.0.3, but its *test-suite* requires tasty-hedgehog >=1.0.0.2 && < 1.2 and the snapshot contains tasty-hedgehog-1.4.0.2
+    - TotalMap # tried TotalMap-0.1.1.1, but its *test-suite* requires markdown-unlit >=0.5 && < 0.6 and the snapshot contains markdown-unlit-0.6.0
+    - airship # tried airship-0.9.5, but its *test-suite* requires bytestring >=0.9.1 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+    - airship # tried airship-0.9.5, but its *test-suite* requires tasty >=0.10.1 && < 1.3 and the snapshot contains tasty-1.4.3
+    - airship # tried airship-0.9.5, but its *test-suite* requires text >=1.2 && < 2.0 and the snapshot contains text-2.0.2
+    - antiope-s3 # tried antiope-s3-7.5.3, but its *test-suite* requires hedgehog >=0.5 && < 1.1 and the snapshot contains hedgehog-1.4
+    - antiope-s3 # tried antiope-s3-7.5.3, but its *test-suite* requires hspec >=2.4 && < 2.8 and the snapshot contains hspec-2.11.7
+    - arbor-lru-cache # tried arbor-lru-cache-0.1.1.1, but its *test-suite* requires hedgehog >=0.5 && < 1.1 and the snapshot contains hedgehog-1.4
+    - arbor-lru-cache # tried arbor-lru-cache-0.1.1.1, but its *test-suite* requires hspec >=2.4 && < 2.8 and the snapshot contains hspec-2.11.7
+    - ascii-group # tried ascii-group-1.0.0.16, but its *test-suite* requires hedgehog ^>=1.1.2 || ^>=1.2 and the snapshot contains hedgehog-1.4
+    - ascii-numbers # tried ascii-numbers-1.2.0.1, but its *test-suite* requires hedgehog ^>=1.1.2 || ^>=1.2 and the snapshot contains hedgehog-1.4
+    - ascii-predicates # tried ascii-predicates-1.0.1.3, but its *test-suite* requires hedgehog ^>=1.1.2 || ^>=1.2 and the snapshot contains hedgehog-1.4
+    - avro # tried avro-0.6.1.2, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - aws-cloudfront-signed-cookies # tried aws-cloudfront-signed-cookies-0.2.0.12, but its *test-suite* requires hedgehog ^>=1.0.5 || ^>=1.1 || ^>=1.2 and the snapshot contains hedgehog-1.4
+    - beam-postgres # tried beam-postgres-0.5.3.1, but its *test-suite* requires the disabled package: tmp-postgres
+    - bits-extra # tried bits-extra-0.0.2.3, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - bits-extra # tried bits-extra-0.0.2.3, but its *test-suite* requires hedgehog >=0.5.3 && < 1.3 and the snapshot contains hedgehog-1.4
+    - bits-extra # tried bits-extra-0.0.2.3, but its *test-suite* requires hspec >=2.4 && < 2.11 and the snapshot contains hspec-2.11.7
+    - blake2 # tried blake2-0.3.0.1, but its *test-suite* requires hlint ^>=3.5 and the snapshot contains hlint-3.6.1
+    - bloodhound # tried bloodhound-0.21.0.0, but its *test-suite* requires the disabled package: quickcheck-properties
+    - boolean-normal-forms # tried boolean-normal-forms-0.0.1.1, but its *test-suite* requires QuickCheck >=2.10 && < 2.14 and the snapshot contains QuickCheck-2.14.3
+    - brittany # tried brittany-0.14.0.2, but its *test-suite* requires hspec ^>=2.8.3 and the snapshot contains hspec-2.11.7
+    - buttplug-hs-core # tried buttplug-hs-core-0.1.0.1, but its *test-suite* requires hspec >=2.7.8 && < 2.9 and the snapshot contains hspec-2.11.7
+    - cabal-install # tried cabal-install-3.10.2.1, but its *test-suite* requires the disabled package: Cabal-QuickCheck
+    - cabal-install # tried cabal-install-3.10.2.1, but its *test-suite* requires the disabled package: Cabal-described
+    - cabal-install # tried cabal-install-3.10.2.1, but its *test-suite* requires the disabled package: Cabal-tree-diff
+    - cassava-conduit # tried cassava-conduit-0.6.5, but its *test-suite* requires QuickCheck ==2.12.* and the snapshot contains QuickCheck-2.14.3
+    - cayley-client # tried cayley-client-0.4.19.2, but its *test-suite* requires aeson >=0.8.0.2 && < 1.6 || ==2.0.* and the snapshot contains aeson-2.1.2.1
+    - chatwork # tried chatwork-0.1.3.5, but its *test-suite* requires hspec >=2.4.1 && < 2.6 and the snapshot contains hspec-2.11.7
+    - chatwork # tried chatwork-0.1.3.5, but its *test-suite* requires servant-server >=0.9.1.1 && < 0.15 and the snapshot contains servant-server-0.20
+    - chatwork # tried chatwork-0.1.3.5, but its *test-suite* requires warp >=3.2.11 && < 3.3 and the snapshot contains warp-3.3.31
+    - cleff # tried cleff-0.3.3.0, but its *test-suite* requires base >=4.12 && < 4.17 and the snapshot contains base-4.18.1.0
+    - cleff # tried cleff-0.3.3.0, but its *test-suite* requires template-haskell >=2.14 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
+    - colour # tried colour-2.3.6, but its *test-suite* requires random >=1.0 && < 1.2 and the snapshot contains random-1.2.1.1
+    - construct # tried construct-0.3.1.1, but its *test-suite* requires markdown-unlit >=0.5 && < 0.6 and the snapshot contains markdown-unlit-0.6.0
+    - construct # tried construct-0.3.1.1, but its *test-suite* requires monoid-subclasses >=1.0 && < 1.2 and the snapshot contains monoid-subclasses-1.2.4.1
+    - crc32c # tried crc32c-0.1.0, but its *test-suite* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+    - csg # tried csg-0.1.0.6, but its *test-suite* requires doctest < 0.17 and the snapshot contains doctest-0.22.2
+    - csg # tried csg-0.1.0.6, but its *test-suite* requires tasty < 1.3 and the snapshot contains tasty-1.4.3
+    - darcs # tried darcs-2.16.5, but its *test-suite* requires leancheck >=0.9 && < 0.10 and the snapshot contains leancheck-1.0.0
+    - dhall-lsp-server # tried dhall-lsp-server-1.1.3, but its *test-suite* requires hspec >=2.7 && < 2.11 and the snapshot contains hspec-2.11.7
+    - dhall-lsp-server # tried dhall-lsp-server-1.1.3, but its *test-suite* requires lsp-test >=0.13.0.0 && < 0.15 and the snapshot contains lsp-test-0.16.0.1
+    - dhall-lsp-server # tried dhall-lsp-server-1.1.3, but its *test-suite* requires lsp-types >=1.2.0.0 && < 1.5 and the snapshot contains lsp-types-2.1.0.0
+    - dialogflow-fulfillment # tried dialogflow-fulfillment-0.1.1.4, but its *test-suite* requires hspec >=2.7.1 && < 2.9.0 and the snapshot contains hspec-2.11.7
+    - dialogflow-fulfillment # tried dialogflow-fulfillment-0.1.1.4, but its *test-suite* requires hspec-discover >=2.7.1 && < 2.9.0 and the snapshot contains hspec-discover-2.11.7
+    - distributed-process-lifted # tried distributed-process-lifted-0.3.0.1, but its *test-suite* requires the disabled package: network-transport-tcp
+    - distributed-process-lifted # tried distributed-process-lifted-0.3.0.1, but its *test-suite* requires the disabled package: rematch
+    - docopt # tried docopt-0.7.0.7, but its *test-suite* requires template-haskell >=2.15.0 && < 2.18 and the snapshot contains template-haskell-2.20.0.0
+    - doldol # tried doldol-0.4.1.2, but its *test-suite* requires the disabled package: test-framework-th
+    - drawille # tried drawille-0.1.3.0, but its *test-suite* requires containers ==0.5.* and the snapshot contains containers-0.6.7
+    - drawille # tried drawille-0.1.3.0, but its *test-suite* requires hspec >=1.11 && < 2.4 and the snapshot contains hspec-2.11.7
+    - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* requires QuickCheck >=2.4 && < 2.9 and the snapshot contains QuickCheck-2.14.3
+    - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* requires directory >=1.0 && < 1.3 and the snapshot contains directory-1.3.8.1
+    - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* requires doctest >=0.10 && < 0.12 and the snapshot contains doctest-0.22.2
+    - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* requires hlint >=1.7 && < 1.10 and the snapshot contains hlint-3.6.1
+    - edit # tried edit-1.0.1.0, but its *test-suite* requires doctest >=0.13 && < 0.17 and the snapshot contains doctest-0.22.2
+    - edit # tried edit-1.0.1.0, but its *test-suite* requires tasty >=1.0 && < 1.2 and the snapshot contains tasty-1.4.3
+    - edit # tried edit-1.0.1.0, but its *test-suite* requires tasty-discover >=4.2 && < 4.3 and the snapshot contains tasty-discover-5.0.0
+    - errors-ext # tried errors-ext-0.4.2, but its *test-suite* requires the disabled package: binary-ext
+    - euler-tour-tree # tried euler-tour-tree-0.1.1.0, but its *test-suite* requires the disabled package: sequence
+    - eventsource-stub-store # tried eventsource-stub-store-1.1.1, but its *test-suite* requires the disabled package: eventsource-store-specs
+    - extensible-effects # tried extensible-effects-5.0.0.1, but its *test-suite* requires the disabled package: test-framework-th
+    - fclabels # tried fclabels-2.0.5.1, but its *test-suite* requires transformers < 0.6 and the snapshot contains transformers-0.6.1.0
+    - feed # tried feed-1.3.2.1, but its *test-suite* requires markdown-unlit >=0.4 && < 0.6 and the snapshot contains markdown-unlit-0.6.0
+    - filepath-bytestring # tried filepath-bytestring-1.4.2.1.13, but its *test-suite* requires filepath >=1.4.2 && < =1.4.100.3 and the snapshot contains filepath-1.4.100.4
+    - filtrable # tried filtrable-0.1.6.0, but its *test-suite* requires tasty >=1.3.1 && < 1.4 and the snapshot contains tasty-1.4.3
+    - fixed-vector-hetero # tried fixed-vector-hetero-0.6.1.1, but its *test-suite* requires doctest >=0.15 && < 0.20 and the snapshot contains doctest-0.22.2
+    - focuslist # tried focuslist-0.1.1.0, but its *test-suite* requires genvalidity < 1.0.0.0 and the snapshot contains genvalidity-1.1.0.0
+    - focuslist # tried focuslist-0.1.1.0, but its *test-suite* requires validity < 0.12.0.0 and the snapshot contains validity-0.12.0.2
+    - ftp-client # tried ftp-client-0.5.1.4, but its *test-suite* requires tasty >=1.2.3 && < 1.3 and the snapshot contains tasty-1.4.3
+    - ftp-client # tried ftp-client-0.5.1.4, but its *test-suite* requires tasty-hspec >=1.1.5.1 && < 1.2 and the snapshot contains tasty-hspec-1.2.0.4
+    - fused-effects # tried fused-effects-1.1.2.2, but its *test-suite* requires hedgehog >=1 && < 1.3 and the snapshot contains hedgehog-1.4
+    - fused-effects # tried fused-effects-1.1.2.2, but its *test-suite* requires markdown-unlit ^>=0.5 and the snapshot contains markdown-unlit-0.6.0
+    - galois-field # tried galois-field-1.0.2, but its *test-suite* requires QuickCheck >=2.13 && < 2.14 and the snapshot contains QuickCheck-2.14.3
+    - galois-field # tried galois-field-1.0.2, but its *test-suite* requires bitvec >=1.0.2 && < 1.1 and the snapshot contains bitvec-1.1.5.0
+    - galois-field # tried galois-field-1.0.2, but its *test-suite* requires groups >=0.4.1 && < 0.5 and the snapshot contains groups-0.5.3
+    - galois-field # tried galois-field-1.0.2, but its *test-suite* requires integer-gmp >=1.0.2 && < 1.1 and the snapshot contains integer-gmp-1.1
+    - galois-field # tried galois-field-1.0.2, but its *test-suite* requires semirings >=0.5 && < 0.6 and the snapshot contains semirings-0.6
+    - galois-field # tried galois-field-1.0.2, but its *test-suite* requires tasty >=1.2 && < 1.3 and the snapshot contains tasty-1.4.3
+    - generic-xmlpickler # tried generic-xmlpickler-0.1.0.6, but its *test-suite* requires tasty >=0.10 && < 1.3 and the snapshot contains tasty-1.4.3
+    - geojson # tried geojson-4.1.1, but its *test-suite* requires hspec >=2.5 && < 2.10 and the snapshot contains hspec-2.11.7
+    - hal # tried hal-1.0.0.1, but its *test-suite* requires hedgehog >=1.0.3 && < 1.2 and the snapshot contains hedgehog-1.4
+    - hal # tried hal-1.0.0.1, but its *test-suite* requires vector >=0.12.0.0 && < 0.13 and the snapshot contains vector-0.13.1.0
+    - hasbolt # tried hasbolt-0.1.6.3, but its *test-suite* requires hspec >=2.4.1 && < 2.11 and the snapshot contains hspec-2.11.7
+    - haskell-names # tried haskell-names-0.9.9, but its *test-suite* requires tasty >=0.12 && < 1.3 and the snapshot contains tasty-1.4.3
+    - haskell-tools-builtin-refactorings # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *test-suite* requires tasty >=0.11 && < 1.2 and the snapshot contains tasty-1.4.3
+    - haskell-tools-builtin-refactorings # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *test-suite* requires time >=1.8 && < 1.9 and the snapshot contains time-1.12.2
+    - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *test-suite* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+    - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *test-suite* requires knob >=0.1 && < 0.2 and the snapshot contains knob-0.2.2
+    - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *test-suite* requires tasty >=0.11 && < 1.2 and the snapshot contains tasty-1.4.3
+    - haskell-tools-daemon # tried haskell-tools-daemon-1.1.1.0, but its *test-suite* requires Glob >=0.9 && < 0.10 and the snapshot contains Glob-0.10.2
+    - haskell-tools-daemon # tried haskell-tools-daemon-1.1.1.0, but its *test-suite* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.5.2
+    - haskell-tools-daemon # tried haskell-tools-daemon-1.1.1.0, but its *test-suite* requires tasty >=0.11 && < 1.2 and the snapshot contains tasty-1.4.3
+    - haskell-tools-demo # tried haskell-tools-demo-1.1.1.0, but its *test-suite* requires network >=2.6 && < 2.9 and the snapshot contains network-3.1.4.0
+    - haskell-tools-demo # tried haskell-tools-demo-1.1.1.0, but its *test-suite* requires tasty >=0.11 && < 1.2 and the snapshot contains tasty-1.4.3
+    - haskell-tools-refactor # tried haskell-tools-refactor-1.1.1.0, but its *test-suite* requires polyparse >=1.12 && < 1.13 and the snapshot contains polyparse-1.13
+    - haskell-tools-refactor # tried haskell-tools-refactor-1.1.1.0, but its *test-suite* requires tasty >=0.11 && < 1.2 and the snapshot contains tasty-1.4.3
+    - haskell-tools-refactor # tried haskell-tools-refactor-1.1.1.0, but its *test-suite* requires time >=1.8 && < 1.9 and the snapshot contains time-1.12.2
+    - haskell-tools-rewrite # tried haskell-tools-rewrite-1.1.1.0, but its *test-suite* requires tasty >=0.11 && < 1.2 and the snapshot contains tasty-1.4.3
+    - haskey # tried haskey-0.3.1.0, but its *test-suite* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
+    - haskey-mtl # tried haskey-mtl-0.3.1.0, but its *test-suite* requires lens >=4.12 && < 5 and the snapshot contains lens-5.2.3
+    - haskey-mtl # tried haskey-mtl-0.3.1.0, but its *test-suite* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
+    - hasmin # tried hasmin-1.0.3, but its *test-suite* requires doctest >=0.11 && < 0.17 and the snapshot contains doctest-0.22.2
+    - hidden-char # tried hidden-char-0.1.0.2, but its *test-suite* requires hspec >=2.2 && < 2.8 and the snapshot contains hspec-2.11.7
+    - hjsonpointer # tried hjsonpointer-1.5.0, but its *test-suite* requires QuickCheck < 2.12 and the snapshot contains QuickCheck-2.14.3
+    - hjsonpointer # tried hjsonpointer-1.5.0, but its *test-suite* requires base < 4.12 and the snapshot contains base-4.18.1.0
+    - hjsonpointer # tried hjsonpointer-1.5.0, but its *test-suite* requires hspec >=2.2 && < 2.6 and the snapshot contains hspec-2.11.7
+    - hledger-iadd # tried hledger-iadd-1.3.19, but its *test-suite* requires hledger-lib >=1.31 && < 1.32 and the snapshot contains hledger-lib-1.32.1
+    - hsdev # tried hsdev-0.3.4.0, but its *test-suite* requires lens-aeson >=1.0 && < 1.2 and the snapshot contains lens-aeson-1.2.3
+    - hspec-need-env # tried hspec-need-env-0.1.0.10, but its *test-suite* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+    - hspec-tables # tried hspec-tables-0.0.1, but its *test-suite* requires hspec ==2.7.* and the snapshot contains hspec-2.11.7
+    - hw-balancedparens # tried hw-balancedparens-0.4.1.3, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-balancedparens # tried hw-balancedparens-0.4.1.3, but its *test-suite* requires hedgehog >=1.0 && < 1.3 and the snapshot contains hedgehog-1.4
+    - hw-bits # tried hw-bits-0.7.2.2, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-bits # tried hw-bits-0.7.2.2, but its *test-suite* requires hedgehog >=0.6 && < 1.3 and the snapshot contains hedgehog-1.4
+    - hw-conduit # tried hw-conduit-0.2.1.1, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-diagnostics # tried hw-diagnostics-0.0.1.0, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-eliasfano # tried hw-eliasfano-0.1.2.1, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-eliasfano # tried hw-eliasfano-0.1.2.1, but its *test-suite* requires hedgehog >=0.6 && < 1.3 and the snapshot contains hedgehog-1.4
+    - hw-excess # tried hw-excess-0.2.3.0, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-excess # tried hw-excess-0.2.3.0, but its *test-suite* requires hedgehog >=0.6 && < 1.3 and the snapshot contains hedgehog-1.4
+    - hw-fingertree # tried hw-fingertree-0.1.2.1, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-fingertree # tried hw-fingertree-0.1.2.1, but its *test-suite* requires hedgehog >=0.6 && < 1.3 and the snapshot contains hedgehog-1.4
+    - hw-fingertree-strict # tried hw-fingertree-strict-0.1.2.1, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-fingertree-strict # tried hw-fingertree-strict-0.1.2.1, but its *test-suite* requires hedgehog >=0.6 && < 1.3 and the snapshot contains hedgehog-1.4
+    - hw-hedgehog # tried hw-hedgehog-0.1.1.1, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-int # tried hw-int-0.0.2.0, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-int # tried hw-int-0.0.2.0, but its *test-suite* requires hedgehog >=0.6 && < 1.3 and the snapshot contains hedgehog-1.4
+    - hw-ip # tried hw-ip-2.4.2.1, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-ip # tried hw-ip-2.4.2.1, but its *test-suite* requires hedgehog >=0.6 && < 1.3 and the snapshot contains hedgehog-1.4
+    - hw-json # tried hw-json-1.3.2.4, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-json # tried hw-json-1.3.2.4, but its *test-suite* requires hedgehog >=0.6 && < 1.3 and the snapshot contains hedgehog-1.4
+    - hw-json-simd # tried hw-json-simd-0.1.1.2, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-json-simple-cursor # tried hw-json-simple-cursor-0.1.1.1, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-json-simple-cursor # tried hw-json-simple-cursor-0.1.1.1, but its *test-suite* requires hedgehog >=0.6 && < 1.3 and the snapshot contains hedgehog-1.4
+    - hw-json-standard-cursor # tried hw-json-standard-cursor-0.2.3.2, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-json-standard-cursor # tried hw-json-standard-cursor-0.2.3.2, but its *test-suite* requires hedgehog >=0.6 && < 1.3 and the snapshot contains hedgehog-1.4
+    - hw-mquery # tried hw-mquery-0.2.1.1, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-mquery # tried hw-mquery-0.2.1.1, but its *test-suite* requires hedgehog >=0.6.1 && < 1.3 and the snapshot contains hedgehog-1.4
+    - hw-packed-vector # tried hw-packed-vector-0.2.1.1, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-packed-vector # tried hw-packed-vector-0.2.1.1, but its *test-suite* requires hedgehog >=0.6 && < 1.3 and the snapshot contains hedgehog-1.4
+    - hw-parser # tried hw-parser-0.1.1.0, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-parser # tried hw-parser-0.1.1.0, but its *test-suite* requires hedgehog >=1.0 && < 1.3 and the snapshot contains hedgehog-1.4
+    - hw-prim # tried hw-prim-0.6.3.2, but its *test-suite* requires doctest >=0.16.2 && < 0.22 and the snapshot contains doctest-0.22.2
+    - hw-prim # tried hw-prim-0.6.3.2, but its *test-suite* requires hedgehog >=1.0 && < 1.4 and the snapshot contains hedgehog-1.4
+    - hw-rankselect # tried hw-rankselect-0.13.4.1, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-rankselect # tried hw-rankselect-0.13.4.1, but its *test-suite* requires hedgehog >=1.0 && < 1.3 and the snapshot contains hedgehog-1.4
+    - hw-rankselect-base # tried hw-rankselect-base-0.3.4.1, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-rankselect-base # tried hw-rankselect-base-0.3.4.1, but its *test-suite* requires hedgehog >=0.6 && < 1.3 and the snapshot contains hedgehog-1.4
+    - hw-simd # tried hw-simd-0.1.2.2, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-simd # tried hw-simd-0.1.2.2, but its *test-suite* requires hedgehog >=0.5 && < 1.3 and the snapshot contains hedgehog-1.4
+    - hw-string-parse # tried hw-string-parse-0.0.0.5, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-xml # tried hw-xml-0.5.1.1, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
+    - hw-xml # tried hw-xml-0.5.1.1, but its *test-suite* requires hedgehog >=1.0 && < 1.3 and the snapshot contains hedgehog-1.4
+    - indexed-containers # tried indexed-containers-0.1.0.2, but its *test-suite* requires hspec >=2.4.8 && < 2.8 and the snapshot contains hspec-2.11.7
+    - influxdb # tried influxdb-1.9.3, but its *test-suite* requires doctest >=0.11.3 && < 0.22 and the snapshot contains doctest-0.22.2
+    - integer-types # tried integer-types-0.1.4.0, but its *test-suite* requires hedgehog ^>=1.0.5 || ^>=1.1 || ^>=1.2 and the snapshot contains hedgehog-1.4
+    - integer-types # tried integer-types-0.1.4.0, but its *test-suite* requires hspec-hedgehog ^>=0.0.1 and the snapshot contains hspec-hedgehog-0.1.1.0
+    - irc-dcc # tried irc-dcc-2.0.1, but its *test-suite* requires tasty >=0.11.0.2 && < 1.2 and the snapshot contains tasty-1.4.3
+    - irc-dcc # tried irc-dcc-2.0.1, but its *test-suite* requires tasty-hspec >=1.1.2 && < 1.2 and the snapshot contains tasty-hspec-1.2.0.4
+    - json-rpc-client # tried json-rpc-client-0.2.5.0, but its *test-suite* requires QuickCheck >=2.4.2 && < 2.14 and the snapshot contains QuickCheck-2.14.3
+    - libjwt-typed # tried libjwt-typed-0.2, but its *test-suite* requires hspec ==2.7.* and the snapshot contains hspec-2.11.7
+    - libjwt-typed # tried libjwt-typed-0.2, but its *test-suite* requires hspec-core ==2.7.* and the snapshot contains hspec-core-2.11.7
+    - linear-accelerate # tried linear-accelerate-0.7.0.0, but its *test-suite* requires doctest >=0.11.1 && < 0.17 and the snapshot contains doctest-0.22.2
+    - loc # tried loc-0.2.0.0, but its *test-suite* requires hedgehog ^>=1.0.5 || ^>=1.1 || ^>=1.2 and the snapshot contains hedgehog-1.4
+    - loc # tried loc-0.2.0.0, but its *test-suite* requires hspec-hedgehog ^>=0.0.1 and the snapshot contains hspec-hedgehog-0.1.1.0
+    - loopbreaker # tried loopbreaker-0.1.1.1, but its *test-suite* requires inspection-testing >=0.4.2.1 && < 0.5 and the snapshot contains inspection-testing-0.5.0.2
+    - lrucaching # tried lrucaching-0.3.3, but its *test-suite* requires hspec >=2.2 && < 2.8 and the snapshot contains hspec-2.11.7
+    - lrucaching # tried lrucaching-0.3.3, but its *test-suite* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+    - lxd-client # tried lxd-client-0.1.0.6, but its *test-suite* requires turtle >=1.3.6 && < 1.6 and the snapshot contains turtle-1.6.2
+    - makefile # tried makefile-1.1.0.0, but its *test-suite* requires Glob >=0.7 && < 0.9 and the snapshot contains Glob-0.10.2
+    - makefile # tried makefile-1.1.0.0, but its *test-suite* requires QuickCheck >=2.9.2 && < 2.11 and the snapshot contains QuickCheck-2.14.3
+    - makefile # tried makefile-1.1.0.0, but its *test-suite* requires base >=4.9.1.0 && < 4.10 and the snapshot contains base-4.18.1.0
+    - makefile # tried makefile-1.1.0.0, but its *test-suite* requires doctest >=0.9 && < 0.12 and the snapshot contains doctest-0.22.2
+    - makefile # tried makefile-1.1.0.0, but its *test-suite* requires tasty ==0.11.* and the snapshot contains tasty-1.4.3
+    - makefile # tried makefile-1.1.0.0, but its *test-suite* requires tasty-hunit ==0.9.* and the snapshot contains tasty-hunit-0.10.1
+    - makefile # tried makefile-1.1.0.0, but its *test-suite* requires tasty-quickcheck ==0.8.* and the snapshot contains tasty-quickcheck-0.10.2
+    - medea # tried medea-1.2.0, but its *test-suite* requires hspec >=2.7.1 && < 2.9.0 and the snapshot contains hspec-2.11.7
+    - medea # tried medea-1.2.0, but its *test-suite* requires hspec-core >=2.7.1 && < 2.9.0 and the snapshot contains hspec-core-2.11.7
+    - menshen # tried menshen-0.0.3, but its *test-suite* requires QuickCheck < 2.14 and the snapshot contains QuickCheck-2.14.3
+    - monad-par # tried monad-par-0.3.6, but its *test-suite* requires the disabled package: test-framework-th
+    - monad-peel # tried monad-peel-0.3, but its *test-suite* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+    - mwc-random # tried mwc-random-0.15.0.2, but its *test-suite* requires doctest >=0.15 && < 0.20 and the snapshot contains doctest-0.22.2
+    - nakadi-client # tried nakadi-client-0.7.0.0, but its *test-suite* requires classy-prelude >=1.4.0 && < 1.5.0 and the snapshot contains classy-prelude-1.5.0.3
+    - next-ref # tried next-ref-0.1.0.2, but its *test-suite* requires hspec >=2 && < 2.3 and the snapshot contains hspec-2.11.7
+    - numhask-prelude # tried numhask-prelude-0.5.0, but its *test-suite* requires doctest >=0.13 && < 0.17 and the snapshot contains doctest-0.22.2
+    - o-clock # tried o-clock-1.4.0, but its *test-suite* requires hedgehog >=0.6 && < 1.4 and the snapshot contains hedgehog-1.4
+    - oops # tried oops-0.2.0.1, but its *test-suite* requires doctest >=0.16.2 && < 0.22 and the snapshot contains doctest-0.22.2
+    - options # tried options-1.2.1.2, but its *test-suite* requires the disabled package: patience
+    - oset # tried oset-0.4.0.1, but its *test-suite* requires hspec >=2.2 && < 2.8 and the snapshot contains hspec-2.11.7
+    - oset # tried oset-0.4.0.1, but its *test-suite* requires hspec-discover >=2.2 && < 2.8 and the snapshot contains hspec-discover-2.11.7
+    - partial-semigroup # tried partial-semigroup-0.6.0.2, but its *test-suite* requires hedgehog ^>=1.1.2 || ^>=1.2 and the snapshot contains hedgehog-1.4
+    - peregrin # tried peregrin-0.4.2, but its *test-suite* requires transformers >=0.5.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+    - pg-transact # tried pg-transact-0.3.2.0, but its *test-suite* requires the disabled package: tmp-postgres
+    - pipes-category # tried pipes-category-0.3.0.0, but its *test-suite* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+    - pipes-extras # tried pipes-extras-1.0.15, but its *test-suite* requires transformers >=0.2.0.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+    - pipes-fluid # tried pipes-fluid-0.6.0.1, but its *test-suite* requires the disabled package: pipes-misc
+    - postgresql-libpq-notify # tried postgresql-libpq-notify-0.2.0.0, but its *test-suite* requires the disabled package: tmp-postgres
+    - postgrest # tried postgrest-9.0.1, but its *test-suite* requires hspec >=2.3 && < 2.9 and the snapshot contains hspec-2.11.7
+    - pretty-sop # tried pretty-sop-0.2.0.3, but its *test-suite* requires markdown-unlit >=0.5.0 && < 0.6 and the snapshot contains markdown-unlit-0.6.0
+    - prettyprinter # tried prettyprinter-1.7.1, but its *test-suite* requires the disabled package: pgp-wordlist
+    - printcess # tried printcess-0.1.0.3, but its *test-suite* requires HUnit >=1.3 && < 1.6 and the snapshot contains HUnit-1.6.2.0
+    - printcess # tried printcess-0.1.0.3, but its *test-suite* requires QuickCheck >=2.8 && < 2.10 and the snapshot contains QuickCheck-2.14.3
+    - qnap-decrypt # tried qnap-decrypt-0.3.5, but its *test-suite* requires hspec >=2.4.8 && < 2.8 and the snapshot contains hspec-2.11.7
+    - quickcheck-groups # tried quickcheck-groups-0.0.1.0, but its *test-suite* requires hspec >=2.10.7 && < 2.11 and the snapshot contains hspec-2.11.7
+    - quickcheck-monoid-subclasses # tried quickcheck-monoid-subclasses-0.3.0.0, but its *test-suite* requires hspec >=2.10.7 && < 2.11 and the snapshot contains hspec-2.11.7
+    - rakuten # tried rakuten-0.1.1.5, but its *test-suite* requires hspec >=2.4.1 && < 2.6 and the snapshot contains hspec-2.11.7
+    - rakuten # tried rakuten-0.1.1.5, but its *test-suite* requires servant-server >=0.9.1.1 && < 0.15 and the snapshot contains servant-server-0.20
+    - rakuten # tried rakuten-0.1.1.5, but its *test-suite* requires warp >=3.2.11 && < 3.3 and the snapshot contains warp-3.3.31
+    - rank2classes # tried rank2classes-1.5.3, but its *test-suite* requires markdown-unlit >=0.5 && < 0.6 and the snapshot contains markdown-unlit-0.6.0
+    - records-sop # tried records-sop-0.1.1.1, but its *test-suite* requires hspec >=2.2 && < 2.11 and the snapshot contains hspec-2.11.7
+    - rel8 # tried rel8-1.4.1.0, but its *test-suite* requires hedgehog ^>=1.0 || ^>=1.1 and the snapshot contains hedgehog-1.4
+    - rel8 # tried rel8-1.4.1.0, but its *test-suite* requires the disabled package: tmp-postgres
+    - req-url-extra # tried req-url-extra-0.1.1.0, but its *test-suite* requires hspec >=2.2 && < 2.8 and the snapshot contains hspec-2.11.7
+    - roc-id # tried roc-id-0.2.0.0, but its *test-suite* requires hspec >=2.5.5 && < 2.11 and the snapshot contains hspec-2.11.7
+    - salak-toml # tried salak-toml-0.3.5.3, but its *test-suite* requires QuickCheck < 2.14 and the snapshot contains QuickCheck-2.14.3
+    - scale # tried scale-1.0.0.0, but its *test-suite* requires hspec >=2.4.4 && < 2.8 and the snapshot contains hspec-2.11.7
+    - scale # tried scale-1.0.0.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.8 and the snapshot contains hspec-discover-2.11.7
+    - scalendar # tried scalendar-1.2.0, but its *test-suite* requires the disabled package: SCalendar
+    - schematic # tried schematic-0.5.1.0, but its *test-suite* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.1.0
+    - servant-cassava # tried servant-cassava-0.10.2, but its *test-suite* requires servant-server >=0.4.4.5 && < 0.20 and the snapshot contains servant-server-0.20
+    - servant-docs-simple # tried servant-docs-simple-0.4.0.0, but its *test-suite* requires hspec >=2.7.1 && < 2.9 and the snapshot contains hspec-2.11.7
+    - servant-docs-simple # tried servant-docs-simple-0.4.0.0, but its *test-suite* requires hspec-core >=2.7.1 && < 2.9 and the snapshot contains hspec-core-2.11.7
+    - servant-js # tried servant-js-0.9.4.2, but its *test-suite* requires the disabled package: language-ecmascript
+    - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.2.1
+    - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* requires hspec >=2.4.1 && < 2.8 and the snapshot contains hspec-2.11.7
+    - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* requires http-api-data >=0.3.7 && < 0.4.2 and the snapshot contains http-api-data-0.5.1
+    - servant-mock # tried servant-mock-0.8.7, but its *test-suite* requires hspec-wai >=0.9.0 && < 0.11 and the snapshot contains hspec-wai-0.11.1
+    - servant-quickcheck # tried servant-quickcheck-0.0.10.0, but its *test-suite* requires hspec-core >=2.5.5 && < 2.8 and the snapshot contains hspec-core-2.11.7
+    - servant-streaming # tried servant-streaming-0.3.0.0, but its *test-suite* requires QuickCheck >=2.8 && < 2.13 and the snapshot contains QuickCheck-2.14.3
+    - servant-streaming-client # tried servant-streaming-client-0.3.0.0, but its *test-suite* requires QuickCheck >=2.8 && < 2.12 and the snapshot contains QuickCheck-2.14.3
+    - servant-streaming-server # tried servant-streaming-server-0.3.0.0, but its *test-suite* requires QuickCheck >=2.8 && < 2.12 and the snapshot contains QuickCheck-2.14.3
+    - servant-streaming-server # tried servant-streaming-server-0.3.0.0, but its *test-suite* requires streaming-bytestring >=0.1 && < 0.2 and the snapshot contains streaming-bytestring-0.3.2
+    - servant-streaming-server # tried servant-streaming-server-0.3.0.0, but its *test-suite* requires warp >=3.2.4 && < 3.3 and the snapshot contains warp-3.3.31
+    - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* requires aeson >=1.4.1.0 && < 1.5 and the snapshot contains aeson-2.1.2.1
+    - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* requires base-compat >=0.10.5 && < 0.12 and the snapshot contains base-compat-0.13.1
+    - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* requires servant-server >=0.15 && < 0.18 and the snapshot contains servant-server-0.20
+    - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* requires hspec >=2.4.4 && < 2.5 and the snapshot contains hspec-2.11.7
+    - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* requires the disabled package: network-transport-tcp
+    - sexpr-parser # tried sexpr-parser-0.2.2.0, but its *test-suite* requires hspec >=2.5 && < 2.10 and the snapshot contains hspec-2.11.7
+    - simple-log # tried simple-log-0.9.12, but its *test-suite* requires hspec >=2.3 && < 2.8 and the snapshot contains hspec-2.11.7
+    - sized-grid # tried sized-grid-0.2.0.1, but its *test-suite* requires ansi-terminal >=0.8.0.2 && < 0.10 and the snapshot contains ansi-terminal-1.0
+    - sized-grid # tried sized-grid-0.2.0.1, but its *test-suite* requires markdown-unlit >=0.5.0 && < 0.6 and the snapshot contains markdown-unlit-0.6.0
+    - slack-web # tried slack-web-1.6.1.0, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.11 and the snapshot contains hspec-discover-2.11.7
+    - spdx # tried spdx-1.0.0.3, but its *test-suite* requires base-compat ^>=0.10.5 || ^>=0.11.1 || ^>=0.12.1 and the snapshot contains base-compat-0.13.1
+    - sqlite-simple-errors # tried sqlite-simple-errors-0.6.1.0, but its *test-suite* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+    - stb-image-redux # tried stb-image-redux-0.2.1.2, but its *test-suite* requires hspec >=2.1.5 && < 2.5 and the snapshot contains hspec-2.11.7
+    - stm-supply # tried stm-supply-0.2.0.0, but its *test-suite* requires the disabled package: Unique
+    - streaming-cassava # tried streaming-cassava-0.2.0.0, but its *test-suite* requires hspec >=2.4 && < 2.8 and the snapshot contains hspec-2.11.7
+    - streaming-cassava # tried streaming-cassava-0.2.0.0, but its *test-suite* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+    - stripe-http-client # tried stripe-http-client-2.6.2, but its *test-suite* requires hspec >=2.1.0 && < 2.8 and the snapshot contains hspec-2.11.7
+    - strong-path # tried strong-path-1.1.4.0, but its *test-suite* requires hspec >=2.7 && < 2.10 and the snapshot contains hspec-2.11.7
+    - strong-path # tried strong-path-1.1.4.0, but its *test-suite* requires tasty-discover ==4.2.* and the snapshot contains tasty-discover-5.0.0
+    - strongweak # tried strongweak-0.6.0, but its *test-suite* requires hspec >=2.7 && < 2.11 and the snapshot contains hspec-2.11.7
+    - strongweak # tried strongweak-0.6.0, but its *test-suite* requires hspec-discover >=2.7 && < 2.10 and the snapshot contains hspec-discover-2.11.7
+    - sv # tried sv-1.4.0.1, but its *test-suite* requires hedgehog >=0.5 && < 1.1 and the snapshot contains hedgehog-1.4
+    - sv # tried sv-1.4.0.1, but its *test-suite* requires lens >=4 && < 4.20 and the snapshot contains lens-5.2.3
+    - sv # tried sv-1.4.0.1, but its *test-suite* requires semigroups >=0.18 && < 0.20 and the snapshot contains semigroups-0.20
+    - sv # tried sv-1.4.0.1, but its *test-suite* requires tasty >=0.11 && < 1.3 and the snapshot contains tasty-1.4.3
+    - sv # tried sv-1.4.0.1, but its *test-suite* requires tasty-hedgehog >=0.1 && < 1.1 and the snapshot contains tasty-hedgehog-1.4.0.2
+    - sv # tried sv-1.4.0.1, but its *test-suite* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+    - sv # tried sv-1.4.0.1, but its *test-suite* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
+    - sv-cassava # tried sv-cassava-0.3, but its *test-suite* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+    - sv-core # tried sv-core-0.5, but its *test-suite* requires tasty >=0.11 && < 1.3 and the snapshot contains tasty-1.4.3
+    - swagger2 # tried swagger2-2.8.7, but its *test-suite* requires hspec >=2.5.5 && < 2.11 and the snapshot contains hspec-2.11.7
+    - swagger2 # tried swagger2-2.8.7, but its *test-suite* requires hspec-discover >=2.5.5 && < 2.9 and the snapshot contains hspec-discover-2.11.7
+    - system-fileio # tried system-fileio-0.3.16.4, but its *test-suite* requires the disabled package: chell
+    - system-filepath # tried system-filepath-0.4.14, but its *test-suite* requires the disabled package: chell
+    - system-filepath # tried system-filepath-0.4.14, but its *test-suite* requires the disabled package: chell-quickcheck
+    - tar # tried tar-0.5.1.1, but its *test-suite* requires the disabled package: bytestring-handle
+    - tasty-discover # tried tasty-discover-5.0.0, but its *test-suite* requires hspec >=2.7 && < 2.11 and the snapshot contains hspec-2.11.7
+    - tasty-discover # tried tasty-discover-5.0.0, but its *test-suite* requires hspec-core >=2.7.10 && < 2.11 and the snapshot contains hspec-core-2.11.7
+    - temporary-resourcet # tried temporary-resourcet-0.1.0.1, but its *test-suite* requires tasty >=1.0 && < 1.2 and the snapshot contains tasty-1.4.3
+    - test-framework # tried test-framework-0.8.2.0, but its *test-suite* requires the disabled package: libxml
+    - type-errors # tried type-errors-0.2.0.2, but its *test-suite* requires doctest >=0.16.0.1 && < 0.22 and the snapshot contains doctest-0.22.2
+    - type-errors-pretty # tried type-errors-pretty-0.0.1.2, but its *test-suite* requires doctest >=0.16 && < 0.19 and the snapshot contains doctest-0.22.2
+    - ucam-webauth # tried ucam-webauth-0.1.0.0, but its *test-suite* requires QuickCheck >=2.11.3 && < 2.14 and the snapshot contains QuickCheck-2.14.3
+    - ucam-webauth # tried ucam-webauth-0.1.0.0, but its *test-suite* requires generic-random >=1.2.0.0 && < 1.3 and the snapshot contains generic-random-1.5.0.1
+    - ucam-webauth # tried ucam-webauth-0.1.0.0, but its *test-suite* requires hspec >=2.0.0 && < 2.8 and the snapshot contains hspec-2.11.7
+    - ucam-webauth # tried ucam-webauth-0.1.0.0, but its *test-suite* requires the disabled package: time-qq
+    - ucam-webauth-types # tried ucam-webauth-types-0.1.0.0, but its *test-suite* requires hspec >=2.0.0 && < 2.8 and the snapshot contains hspec-2.11.7
+    - uniprot-kb # tried uniprot-kb-0.1.2.0, but its *test-suite* requires QuickCheck >=2.9 && < 2.14 and the snapshot contains QuickCheck-2.14.3
+    - uniprot-kb # tried uniprot-kb-0.1.2.0, but its *test-suite* requires hspec >=2.4.1 && < 2.8 and the snapshot contains hspec-2.11.7
+    - utf8-light # tried utf8-light-0.4.4.0, but its *test-suite* requires hspec >=2.3 && < 2.11 and the snapshot contains hspec-2.11.7
+    - wai-session-redis # tried wai-session-redis-0.1.0.5, but its *test-suite* requires hspec < 2.10 and the snapshot contains hspec-2.11.7
+    - wakame # tried wakame-0.1.0.0, but its *test-suite* requires tasty-discover >=4.2 && < 5.0 and the snapshot contains tasty-discover-5.0.0
+    - wakame # tried wakame-0.1.0.0, but its *test-suite* requires text >=1.2 && < 2.0 and the snapshot contains text-2.0.2
+    - web-routes-th # tried web-routes-th-0.22.8.1, but its *test-suite* requires hspec >=2.2 && < 2.11 and the snapshot contains hspec-2.11.7
+    - web3-bignum # tried web3-bignum-1.0.0.0, but its *test-suite* requires hspec >=2.4.4 && < 2.8 and the snapshot contains hspec-2.11.7
+    - web3-bignum # tried web3-bignum-1.0.0.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.8 and the snapshot contains hspec-discover-2.11.7
+    - web3-crypto # tried web3-crypto-1.0.0.0, but its *test-suite* requires hspec >=2.4.4 && < 2.8 and the snapshot contains hspec-2.11.7
+    - web3-crypto # tried web3-crypto-1.0.0.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.8 and the snapshot contains hspec-discover-2.11.7
+    - web3-ethereum # tried web3-ethereum-1.0.0.0, but its *test-suite* requires hspec >=2.4.4 && < 2.8 and the snapshot contains hspec-2.11.7
+    - web3-ethereum # tried web3-ethereum-1.0.0.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.8 and the snapshot contains hspec-discover-2.11.7
+    - web3-polkadot # tried web3-polkadot-1.0.0.0, but its *test-suite* requires hspec >=2.4.4 && < 2.8 and the snapshot contains hspec-2.11.7
+    - web3-polkadot # tried web3-polkadot-1.0.0.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.8 and the snapshot contains hspec-discover-2.11.7
+    - web3-solidity # tried web3-solidity-1.0.0.0, but its *test-suite* requires hspec >=2.4.4 && < 2.8 and the snapshot contains hspec-2.11.7
+    - web3-solidity # tried web3-solidity-1.0.0.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.8 and the snapshot contains hspec-discover-2.11.7
+    - wild-bind-x11 # tried wild-bind-x11-0.2.0.15, but its *test-suite* requires time >=1.5.0 && < 1.12 and the snapshot contains time-1.12.2
+    - yesod-static-angular # tried yesod-static-angular-0.1.8, but its *test-suite* requires yesod-test >=1.2 && < 1.6 and the snapshot contains yesod-test-1.6.16
+    - zm # tried zm-0.3.2, but its *test-suite* requires doctest >=0.11.1 && < 0.14 and the snapshot contains doctest-0.22.2
+    - zm # tried zm-0.3.2, but its *test-suite* requires tasty >=0.11 && < 0.13 and the snapshot contains tasty-1.4.3
+    - zm # tried zm-0.3.2, but its *test-suite* requires tasty-quickcheck >=0.8.1 && < 0.9.2 and the snapshot contains tasty-quickcheck-0.10.2
+    - zm # tried zm-0.3.2, but its *test-suite* requires timeit >=1 && < 1.1 and the snapshot contains timeit-2.0
+    # End of Test bounds issues
+
+    # general failures
+    - aern2-mp            # https://github.com/michalkonecny/aern2/issues/11
+
+    # ???
+    - chronos # 1.1.5.1 chronos-test:  executable not found
+    - do-list # 1.0.1 test:  executable not found https://github.com/tserduke/do-list/issues/3
+    - incremental-parser # 0.5.0.3 Main: executable not found
+    - streamt # executable not found
+
+# end of skipped-tests
+
+# Tests listed in expected-test-failures configure correctly but may fail to run
+# or even build correctly. A Stackage build should not fail based on a test build
+# or test run failure for these packages.
+# (Testsuites which can't configure should be placed under skipped-tests.)
+#
+# We need to build and run test suites to verify if tests listed here
+# can be re-enabled, so we usually wait for the maintainer to file a
+# PR to re-enable them.
+expected-test-failures:
+
+    # Compilation failures
+    - Spock # 0.14.0.0
+    - blake2 # 0.3.0
+    - blas-hs # 0.1.1.0
+    - brick # 2.1.1
+    - butter # 0.1.0.6
+    - cabal-file-th # 0.2.7
+    - cacophony # 0.10.1 https://github.com/centromere/cacophony/issues/15
+    - cereal # 0.5.8.3 https://github.com/GaloisInc/cereal/issues/109
+    - conduit-aeson # https://github.com/commercialhaskell/stackage/issues/6469
+    - conduit-connection # 0.1.0.5
+    - cryptohash # 0.11.9 Stack builds test and benchmarks in one pass so benchmark could prevent tests from getting built
+    - crypton-x509 # 1.7.6 https://github.com/kazu-yamamoto/crypton-certificate/issues/1
+    - deriveJsonNoPrefix # 0.1.0.1 compile fail against aeson 2
+    - do-notation # 0.1.0.2
+    - flay # 0.4
+    - generic-lens # https://github.com/commercialhaskell/stackage/issues/6377
+    - geojson # 4.1.0
+    - ghc-byteorder # 4.11.0.0.10 https://github.com/haskell-hvr/ghc-byteorder/issues/1
+    - ghc-prof # Regression tests: /usr/bin/ld.gold: error: cannot find -lHStemporary-1.3-51ST9z47bmaL2YkhqqBGqn_p ...
+    - heap # 1.0.4 https://github.com/pruvisto/heap/issues/11
+    - hourglass # 0.2.12
+    - hweblib # 0.6.3 https://github.com/aycanirican/hweblib/issues/3
+    - inline-r # 1.0.1 https://github.com/tweag/HaskellR/issues/371
+    - leveldb-haskell
+    - lifted-base # 0.2.3.12 compile fail
+    - mfsolve # https://github.com/commercialhaskell/stackage/issues/6379
+    - multiarg # 0.30.0.10
+    - parameterized # 0.5.0.0 https://github.com/commercialhaskell/stackage/issues/5746
+    - protobuf # 0.2.1.4
+    - quickcheck-state-machine # 0.8.0 https://github.com/stevana/quickcheck-state-machine/issues/32
+    - record-wrangler # 0.1.1.0
+    - secp256k1-haskell # #5948/closed
+    - servant-static-th # 1.0.0.0 Tasty issue: https://github.com/commercialhaskell/stackage/issues/6090
+    - snappy # Could not find module ‘Functions’
+    - thread-supervisor # 0.2.0.0
+    - twitter-types # 0.11.0 compile fail against aeson 2
+    - type-of-html-static # 0.1.0.2 https://github.com/commercialhaskell/stackage/issues/5728
+    - ua-parser # 0.7.7.0 compile fail against aeson 2
+    - ua-parser # 0.7.7.0 https://github.com/commercialhaskell/stackage/issues/6440
+    - vformat # 0.14.1.0
+    - vivid-supercollider # 0.4.1.2 https://github.com/commercialhaskell/stackage/issues/4250
+    - xml-html-qq # 0.1.0.1
+    - xmlgen # 0.6.2.2 https://github.com/skogsbaer/xmlgen/issues/6
+
+    # Consistent test failures
+    - Allure # 0.11.0.0
+    - ap-normalize # 0.1.0.1 ghc-9.6
+    - astro # 0.4.3.0 https://github.com/aligusnet/astro/issues/8
+    - generics-eot # 0.4.0.1 ghc-9.6
+    - hsexif # 0.6.1.10 Missing test file
+    - pvar # 1.0.0.0 ghc-9.6
+    - tar-conduit # https://github.com/snoyberg/tar-conduit/issues/33
+    - markov-chain-usage-model # https://github.com/advancedtelematic/markov-chain-usage-model/issues/44
+
+    # Intermittent failures or unreliable. These tests may pass when
+    # re-enabled, but will eventually fail again.
+    #
+    - aeson-lens # https://github.com/tanakh/aeson-lens/issues/10
+    - base64 # https://github.com/emilypi/base64/issues/31
+    - binary-instances # https://github.com/haskellari/binary-instances/issues/7
+    - cabal-debian # https://github.com/ddssff/cabal-debian/issues/50
+    - capataz # https://github.com/roman/Haskell-capataz/issues/6
+    - cardano-coin-selection # 1.0.1 https://github.com/input-output-hk/cardano-coin-selection/issues/93
+    - concurrent-extra # https://github.com/basvandijk/concurrent-extra/issues/12
+    - crypto-numbers
+    - css-text # https://github.com/yesodweb/css-text/issues/10
+    - distributed-process
+    - distributed-process-execution # https://github.com/haskell-distributed/distributed-process-execution/issues/2
+    - distributed-process-task
+    - dl-fedora # status 404 on http download
+    - fft # test-fft:  exited with: ExitFailure (-11)
+    - foldl-statistics # https://github.com/data61/foldl-statistics/issues/2
+    - friday # https://github.com/RaphaelJ/friday/issues/37
+    - fsnotify # Often runs out of inotify handles
+    - hastache
+    - hedn
+    - idris # https://github.com/fpco/stackage/issues/1382
+    - ihaskell # https://github.com/gibiansky/IHaskell/issues/551
+    - kdt # 0.2.5 https://github.com/giogadi/kdt/issues/7
+    - lapack
+    - math-functions # https://github.com/bos/math-functions/issues/25
+    - mltool # https://github.com/Alexander-Ignatyev/mltool/issues/1
+    - network # Unfortunately network failures seem to happen haphazardly
+    - nsis # Intermittent on non-Windows systems
+    - tdigest # 0.3 https://github.com/phadej/tdigest/issues/46
+    - texmath # https://github.com/jgm/texmath/issues/224
+    - tree-diff # 0.3.0.1 https://github.com/haskellari/tree-diff/issues/79
+    - typst # https://github.com/jgm/typst-hs/issues/11
+
+    # Requires running servers, accounts, or a specific environment.
+    #
+    # If a maintainer wants us to run a partial tests suite with tests
+    # that do not require external dependencies, see
+    # https://github.com/commercialhaskell/stackage/issues/6172#issuecomment-902072030
+    #
+    - GLFW-b # X
+    - HTF # Requires shell script and are incompatible with sandboxed package databases
+    - HaRe # Needs ~/.ghc-mod/cabal-helper https://github.com/fpco/stackage/pull/906
+    - IPv6DB
+    - accelerate-bignum # CUDA GPU
+    - aeson-typescript # needs either yarn or npm; one of them is needed to install a TypeScript compiler.
+    - alex
+    - amqp
+    - aws # AWS Credentials
+    - beam-postgres # requires Postgress instance
+    - bindings-GLFW # Expects running X server
+    - bitcoin-api
+    - bitcoin-api-extra
+    - bloodhound # ElasticSearch
+    - cabal-install
+    - cayley-client
+    - consul-haskell
+    - cql-io # Cassandra
+    - credential-store # requieres dbus sockets
+    - datadog # requires API keys in env vars https://github.com/fpco/stackage/pull/3308#issuecomment-369535040
+    - dbcleaner # Requires running PostgreSQL server
+    - dbmigrations # PostgreSQL
+    - dbus # #6373/closed
+    - dns # https://github.com/commercialhaskell/stackage/issues/6374
+    - drifter-postgresql # PostgreSQL
+    - egison # executable not found https://github.com/egison/egison/issues/250
+    - esqueleto # mysql and postgresql
+    - etcd # etcd https://github.com/fpco/stackage/issues/811
+    - eventful-dynamodb
+    - eventful-postgresql
+    - eventsource-geteventstore-store
+    - eventstore # Event Store
+    - faktory # connection refused, https://github.com/commercialhaskell/stackage/issues/5905
+    - fb # Facebook app
+    - gdax # Needs environment variables set
+    - ghc-imported-from # depends on haddocks being generated first https://github.com/fpco/stackage/pull/1315
+    - ghc-mod # https://github.com/DanielG/ghc-mod/issues/611
+    - githash # Needs a git repo
+    - gitson # 0.5.2 error with git executable https://github.com/myfreeweb/gitson/issues/1
+    - gitson # https://github.com/myfreeweb/gitson/issues/1
+    - happy # Needs mtl in the user package DB
+    - haskell-neo4j-client # neo4j with auth disabled
+    - haskell-tools-cli # https://github.com/haskell-tools/haskell-tools/issues/230
+    - haskell-tools-refactor # https://github.com/haskell-tools/haskell-tools/issues/231
+    - hasql # PostgreSQL
+    - hasql-dynamic-statements # PostgreSQL
+    - hasql-notifications # PostgreSQL
+    - hasql-queue
+    - hasql-transaction # PostgreSQL
+    - hedis
+    - hexml-lens # Access to web.archive.org is unreliable.
+    - hie-bios # cabal, stack, ghc; see https://github.com/commercialhaskell/stackage/issues/5025
+    - hjsmin # Test-runner expects a cabal-style 'dist-newstyle' directory
+    - hocilib # oracle
+    - http-api-data-qq # Access to httpbin.org is unreliable (at the moment 504 Gateway Time-out).
+    - http-client # httpbin issues, https://github.com/snoyberg/http-client/issues/439
+    - http-client-tls # Access to httpbin.org is unreliable (at the moment 504 Gateway Time-out).
+    - http-directory # httpbin issues, https://github.com/juhp/http-directory/issues/1
+    - http2 # executable not found https://github.com/kazu-yamamoto/http2/issues/22
+    - hworker
+    - influxdb
+    - json-autotype # Requires filesystem access
+    - jvm
+    - katip-elasticsearch # elasticsearch
+    - log # ElasticSearch
+    - lxd-client # Needs LXD, not available on debian
+    - lz4 # executable not found https://github.com/commercialhaskell/stackage/issues/6226
+    - mangopay # https://github.com/prowdsponsor/mangopay/issues/30
+    - matplotlib # https://github.com/fpco/stackage/issues/2365
+    - memcached-binary # memcached
+    - milena
+    - minio-hs # 1.6.0 Depends on AWS API
+    - mongoDB # Requires local MongoDB server
+    - mysql # MySQL
+    - mysql-haskell # Requires local mysql server with a test account, and binlog enabled.
+    - mysql-simple # MySQL
+    - network-anonymous-i2p
+    - nri-kafka # requires kafka
+    - nri-postgresql # requires postgres
+    - nri-redis # requires redis
+    - odbc # "Need ODBC_TEST_CONNECTION_STRING environment variable"
+    - opaleye # PostgreSQL
+    - optima # `demo` invoked with bad arguments https://github.com/commercialhaskell/stackage/pull/6102
+    - pandoc-plot # requires matlab, etc and DISPLAY for tcltk
+    - pantry # https://github.com/commercialhaskell/stackage/issues/4628
+    - peregrin # Requires running pg-harness-server
+    - persistent-redis # redis - https://github.com/fpco/stackage/pull/1581
+    - pipes-mongodb
+    - postgresql-libpq-notify
+    - postgresql-query # PostgreSQL
+    - postgresql-simple # PostgreSQL
+    - postgresql-simple-migration
+    - postgresql-simple-queue
+    - postgresql-syntax # hedgehog-test executable not found https://github.com/commercialhaskell/stackage/pull/6102
+    - postgresql-typed # PostgreSQL
+    - postgrest # PostgreSQL
+    - purescript # git 128 https://github.com/purescript/purescript/issues/2292
+    - rattle # needs fsatrace
+    - redis-io
+    - rel8
+    - req-conduit # Access to httpbin.org is unreliable (at the moment 504 Gateway Time-out).
+    - rest-rewrite # posix_spawnp
+    - rethinkdb
+    - rethinkdb-client-driver
+    - riak # needs riak server on localhost:8098
+    - sdl2 # "Failed to connect to the Mir Server"
+    - sendgrid-v3 # Requires sendgrid API key in env #5951/closed
+    - serialport # "The tests need two serial ports as command line arguments" https://github.com/jputcu/serialport/issues/30
+    - servant-rate-limit # redis
+    - serversession-backend-persistent # persistent, see https://github.com/commercialhaskell/stackage/pull/6655#issuecomment-1198868074
+    - serversession-backend-redis # redis
+    - shake # Needs ghc on $PATH with some installed haskell packages
+    - slack-api # needs api key https://github.com/commercialhaskell/stackage/pull/5345
+    - sourcemap # requires npm installed packages
+    - squeal-postgresql # ConnectionException "LibPQ.exec", https://github.com/commercialhaskell/stackage/issues/7108
+    - stripe-http-streams # https://github.com/fpco/stackage/issues/2945, needs Stripe account
+    - sydtest-wai # epollControl does not exist. Stackage server issue?
+    - users-persistent # sqlite
+    - users-postgresql-simple # PostgreSQL
+    - yesod-core
+    - wai-cors # PhantomJS
+    - wai-middleware-delegate # Access to httpbin.org is unreliable (at the moment 504 Gateway Time-out).
+    - wai-rate-limit-redis # Redis
+    - wai-session-postgresql # PostgreSQL
+    - wai-session-redis # https://github.com/commercialhaskell/stackage/pull/5980
+    - web3 # requires running server
+    - webdriver-angular # webdriver server
+    - websockets
+
+    # Missing test files in sdist
+    #
+    # The cause is that a test suite requires a file that is not
+    # present in the tarball that is uploaded to Hackage. It can be
+    # fixed by adding these files to `extra-source-files` in the
+    # .cabal file.
+    #
+    - aeson-combinators # https://github.com/turboMaCk/aeson-combinators/issues/31
+    - brittany # https://github.com/commercialhaskell/stackage/issues/6465
+    - cpio-conduit # Test file not in tarball https://github.com/da-x/cpio-conduit/issues/1
+    - crypto-pubkey # https://github.com/vincenthz/hs-crypto-pubkey/issues/23
+    - doctest-discover # https://github.com/karun012/doctest-discover/issues/33
+    - enum-text # https://github.com/cdornan/enum-text/issues/3
+    - ghc-events # https://github.com/haskell/ghc-events/issues/70
+    - gitlab-haskell # https://github.com/commercialhaskell/stackage/issues/6088
+    - hspec-junit-formatter # https://github.com/freckle/hspec-junit-formatter/issues/14
+    - persistent # https://github.com/commercialhaskell/stackage/issues/6037
+    - reanimate-svg # https://github.com/commercialhaskell/stackage/issues/5688
+    - wai-saml2 # https://github.com/mbg/wai-saml2/issues/44
+
+    # Testcase failures, or other runtime failures.
+    # These can be real testsuite bugs, or maybe limitations in test cases or the test setup.
+    - OrderedBits # 0.0.2.0
+    - ShellCheck # https://github.com/commercialhaskell/stackage/issues/6867
+    - ace # failed with ghc-9.4.4
+    - algebraic-graphs # Module not visible https://github.com/commercialhaskell/stackage/issues/4670
+    - binary-generic-combinators # 0.4.4.0 negative quickcheck resize
+    - bsb-http-chunked # 0.0.0.4
+    - c2hs # 0.28.8
+    - cfenv # 0.1.0.0 https://github.com/tomphp/haskell-cfenv/issues/1
+    - character-cases # 0.1.0.6 https://github.com/aiya000/hs-character-cases/issues/3
+    - codec-beam # 0.2.0 posix_spawnp: does not exist
+    - colonnade # 1.2.0.2 https://github.com/andrewthad/colonnade/issues/31
+    - control-dsl # 0.2.1.3
+    - crypt-sha512 # 0 Use -p '/crypt.$6$rounds=10$roundstoolow/' to rerun this test only.
+    - curl-runnings # 0.17.0
+    - download # 0.3.2.7 https://github.com/fpco/stackage/issues/2811
+    - duration # 0.2.0.0
+    - ede # 0.3.3.0 hashable order dependent
+    - fixed-vector-hetero # 0.6.1.1
+    - generic-optics # 2.2.1.0 optimization output https://github.com/kcsongor/generic-lens/issues/133
+    - github-types # https://github.com/commercialhaskell/stackage/issues/6549
+    - haskoin-node # https://github.com/commercialhaskell/stackage/issues/6769
+    - hgeometry-combinatorial # 0.14
+    - hruby # 0.5.1.0
+    - hspec-golden-aeson # 0.9.0.0
+    - invertible # 0.2.0.8 executable not found
+    - justified-containers # 0.3.0.0
+    - jwt # 0.11.0
+    - lattices # quicheck flakiness
+    - list-transformer
+    - lz4-frame-conduit # https://github.com/nh2/lz4-frame-conduit/issues/3
+    - massiv-io
+    - megaparsec-tests
+    - memcache # 0.3.0.1 executable not found
+    - mighty-metropolis # https://github.com/jtobin/mighty-metropolis/issues/6
+    - mixpanel-client # https://github.com/domenkozar/mixpanel-client/issues/7
+    - morpheus-graphql-app
+    - mwc-random
+    - nettle # https://github.com/stbuehler/haskell-nettle/issues/10
+    - nri-observability # https://github.com/commercialhaskell/stackage/issues/6179
+    - nri-prelude # https://github.com/commercialhaskell/stackage/issues/6179
+    - ochintin-daicho
+    - openapi3
+    - openssl-streams # 1.2.3.0 asn1 encoding wrong tag
+    - opentelemetry-extra # 0.8.0 negative quickcheck resize
+    - optics # 0.4.2.1
+    - pcre-heavy
+    - persistent-sqlite # https://github.com/yesodweb/persistent/issues/989
+    - pkgtreediff # 0.6.0
+    - posix-paths
+    - posix-pty # 0.2.2
+    - prettyprinter
+    - prettyprinter-ansi-terminal
+    - product-profunctors # 0.11.0.3 executable not found
+    - rando # https://github.com/commercialhaskell/stackage/issues/4249
+    - rank1dynamic
+    - readline # 1.0.3.0
+    - req # https://github.com/commercialhaskell/stackage/issues/6904
+    - rescue
+    - roc-id # 0.1.0.0 negative quickcheck resize
+    - rose-trees
+    - safe-decimal
+    - simple-affine-space
+    - simple-vec3 # https://github.com/commercialhaskell/stackage/pull/5410
+    - singletons-base
+    - sized
+    - spatial-math
+    - sqids
+    - stateWriter # 0.4.0 https://github.com/bartavelle/stateWriter/issues/6
+    - subcategories
+    - sydtest-yesod # https://github.com/commercialhaskell/stackage/issues/6798
+    - tasty-fail-fast
+    - tasty-html # https://github.com/commercialhaskell/stackage/issues/6966
+    - thyme # 0.4
+    - triplesec
+    - turtle
+    - type-level-kv-list
+    - tzdata # 0.2.20230322.0 - https://github.com/ysangkok/haskell-tzdata/issues/3
+    - unicode-show
+    - universe-some
+    - universum
+    - utf8-conversions
+    - varying
+    - vivid-osc
+    - wai-extra # https://github.com/yesodweb/wai/issues/886
+    - wakame
+    - world-peace
+    - xml-picklers # https://github.com/Philonous/xml-picklers/issues/5
+    - xmlbf
+    - yarn-lock
+    - yesod-gitrev # needs a git repo https://github.com/commercialhaskell/stackage/issues/6132
+    - yesod-markdown # https://github.com/pbrisbin/yesod-markdown/issues/77
+
+    # Assertion failures due to module name ambiguity.
+    # These _should_ be fixed by using the `hide` section of this file
+    - reanimate # https://github.com/commercialhaskell/stackage/issues/5626
+
+    # Recursive deps https://github.com/fpco/stackage/issues/1818
+    - options
+    - text # 1.2.2.1
+
+    # Problem on the stackage build server, we need to dig deeper into
+    # these if we want them fixed
+    - domain-optics # `demo`: executable not found
+    - ghci-hexcalc # https://github.com/takenobu-hs/ghci-hexcalc/issues/2
+    - haskell-tools-daemon # openFile: permission denied https://github.com/fpco/stackage/issues/2502
+    - isocline # segfault https://github.com/daanx/isocline/issues/1
+    - rounded # segfault
+    - shake-language-c # Cannot reproduce locally, looks like it may be a bug in Stack or curator
+    - skein # openfile: does not exist https://github.com/fpco/stackage/issues/1187
+    - genvalidity-text # Suddenly not able to find the executable
+    - safe-coloured-text-layout # Golden output not found
+    - ListLike # listlike-tests:  executable not found
+    - lsp-test # 'posix_spawnp' does not exist, 'hPutBuf: resource vanished (Broken Pipe)' https://github.com/commercialhaskell/stackage/issues/7189
+
+    # doctests can be flaky on the build server, add packages here if
+    # they start causing issues.
+    - bookkeeping
+    - detour-via-sci # https://github.com/commercialhaskell/stackage/issues/6360
+    - dhall
+    - dimensional # CPP issue
+    - doctest-driver-gen
+    - doctest-parallel
+    - dyre
+    - envelope # https://github.com/commercialhaskell/stackage/issues/6383
+    - error
+    - fmt # https://github.com/commercialhaskell/stackage/issues/6375
+    - greskell
+    - greskell-core
+    - headroom
+    - hint
+    - hledger-lib
+    - iproute
+    - kawhi
+    - lens-regex
+    - makefile # Doctests require hidden Glob package
+    - model
+    - multiset # Doctests require hidden Glob package
+    - servant-openapi3
+    - xml-indexed-cursor
+    - yesod-paginator
+
+    # Misc. Please check if there is a better section before adding more packages here.
+    - ghcid # Weird conflicts with sandboxingistributed/distributed-process-supervisor/issues/1
+    - hspec-expectations-pretty-diff # https://github.com/unrelentingtech/hspec-expectations-pretty-diff/issues/7
+    - hw-kafka-client # missing exe https://github.com/commercialhaskell/stackage/pull/5542
+    - pandoc # https://github.com/jgm/pandoc/issues/5582
+    - pcg-random # https://github.com/cchalmers/pcg-random/pull/7
+    - persistent-mongoDB # Requires a running server
+    - persistent-mysql # https://github.com/commercialhaskell/stackage/issues/4764
+    - persistent-postgresql # https://github.com/commercialhaskell/stackage/issues/4763
+    - pg-transact # https://github.com/jfischoff/pg-transact/issues/2
+    - poly
+    - postgresql-simple-queue # same issue as before, see also https://github.com/fpco/stackage/issues/2592 as that will fix both
+    - raaz # https://github.com/commercialhaskell/stackage/issues/4784
+    - rattletrap # OOM? https://github.com/fpco/stackage/issues/2232
+    - relude # doctest fails due to GHC bugs, will be fixed in the next `relude` release
+    - sbv
+    - servant-elm # https://github.com/haskell-servant/servant-elm/issues/62
+    - servant-ruby # Module not visible https://github.com/commercialhaskell/stackage/issues/4650
+    - skews # https://github.com/iij-ii/direct-hs/issues/100
+    - stm-delay # https://github.com/joeyadams/haskell-stm-delay/issues/5
+    - tasty-discover # https://github.com/commercialhaskell/stackage/issues/4722
+    - threads # https://github.com/basvandijk/threads/issues/10
+    - tmp-postgres # https://github.com/jfischoff/tmp-postgres/issues/1
+
+    # Please review the sections above before adding packages to a new section or to Misc.
+
+# end of expected-test-failures
+
+
+# Haddocks which are expected to fail. Same concept as expected test failures.
+expected-haddock-failures:
+
+    # Requires build before haddock, which doesn't always happen in incremental
+    # builds. Could consider special-casing this requirement.
+    - gtk3
+
+    # Intermittent failures or unreliable. These may pass when
+    # re-enabled, but will eventually fail again. Only remove these
+    # from expected-haddock-failures if we know a fix has been released.
+    - gi-gtk # Uses all memory
+
+    # Problem on the stackage build server, we need to dig deeper into
+    # these if we want them fixed
+
+    # internal error when calculating transitive package dependencies
+    - hw-balancedparens
+    - hw-ip # https://github.com/commercialhaskell/stackage/issues/5014
+    - hw-json # https://github.com/commercialhaskell/stackage/issues/5014
+    - hw-rankselect
+    - doctest-parallel # https://github.com/commercialhaskell/stackage/issues/5014
+    - tztime # https://github.com/commercialhaskell/stackage/issues/5014
+
+    # crashes with 9.4.3
+    - MissingH # https://github.com/haskell-hvr/missingh/issues/61
+# end of expected-haddock-failures
+
+# For packages with haddock issues
+skipped-haddocks:
+- amazonka-ec2 # Around 7 GB memory consumption - so do not build haddock to optimize overall performance. For more details see: https://gitlab.haskell.org/ghc/ghc/-/issues/19203, https://github.com/brendanhay/amazonka/issues/549 and related issues.
+- modular # Module uses compiler plugins https://github.com/haskell/haddock/issues/900
+# end of skipped-haddocks
+
+# Benchmarks which are known not to build. Note that, currently we do not run
+# benchmarks, and therefore failures are only for building, not running.
+expected-benchmark-failures:
+    # Compilation failures
+    - OrderedBits # 0.0.2.0
+    - cacophony # 0.10.1
+    - chronos # 1.1.5.1 Ambiguous occurrence ‘Thyme.defaultTimeLocale’
+    - cmark-gfm # https://github.com/kivikakk/cmark-gfm-hs/issues/5
+    - cryptohash # 0.11.9 https://github.com/vincenthz/hs-cryptohash/pull/43
+    - do-list # 1.0.1 https://github.com/tserduke/do-list/issues/3
+    - fast-builder # 0.1.3.0 compile fail against aeson 2
+    - genvalidity-text # 1.0.0.1 https://github.com/NorfairKing/validity/issues/105
+    - hedis # 0.15.2 https://github.com/informatikr/hedis/issues/214
+    - incremental-parser # 0.5.0.3
+    - lz4 # https://github.com/fpco/stackage/issues/3510
+    - memcache # 0.3.0.1
+    - product-profunctors # 0.11.1.1
+    - raaz # https://github.com/commercialhaskell/stackage/issues/4766
+    - stateWriter # 0.4.0 https://github.com/bartavelle/stateWriter/issues/5
+    - ua-parser # 0.7.7.0 compile fail against aeson 2
+    - universum
+    - xmlgen # https://github.com/skogsbaer/xmlgen/issues/6
+
+# end of expected-benchmark-failures
+
+
+# Benchmarks which should not be built.
+# Note that Stackage builds benchmarks but does not run them.
+# By skipping a benchmark, we do not pull in the build dependencies
+# Packages should only be added here if required by `stackage-curator check'
+# or if Setup fails because of missing foreign libraries.
+# Otherwise place them in expected-benchmark-failures.
+skipped-benchmarks:
+    # Cyclic dependencies
+    - Agda
+    - aeson
+    - indexed-traversable-instances
+    - semialign
+    - attoparsec
+    - case-insensitive
+    - cassava
+    - clock
+    - criterion
+    - criterion-measurement
+    - foldable1-classes-compat
+    - foundation
+    - hashable # https://github.com/fpco/stackage/issues/1818
+    - hspec
+    - microstache
+    - nanospec
+    - scientific
+    - statistics
+    - tree-diff
+    - vector-binary-instances
+
+    # Timeouts
+    - gogol-youtube
+
+    # Very resource intensive
+    - OpenGLRaw
+    - pandoc
+    - git-annex
+
+    # Maintainers who don't want to update benchmarks
+    # Only re-enable if requested.
+    ## @hvr https://github.com/fpco/stackage/issues/2538#issuecomment-304458844
+    - uuid
+    - uuid-types
+    # @nikita-volkov https://github.com/fpco/stackage/issues/2538#issuecomment-305129396
+    - base-prelude
+    - bytestring-strict-builder
+    - bytestring-tree-builder
+    - cases
+    - focus
+    - hasql
+    - hasql-pool
+    - list-t
+    - mtl-prelude
+    - neat-interpolation
+    - partial-handler
+    - postgresql-binary
+    - refined
+    - slave-thread
+    - stm-containers
+    - vector-builder
+    # @ivan-m https://github.com/fpco/stackage/issues/2538#issuecomment-307290070
+    - fgl
+    - fgl-arbitrary
+    - graphviz
+    - wl-pprint-text
+    # @phadej
+    - dlist-nonempty # criterion-1.3
+    - splitmix # criterion-1.3
+    # @sjakobi
+    - prettyprinter
+    - prettyprinter-ansi-terminal # https://github.com/commercialhaskell/stackage/issues/5560
+
+    # See "Large scale enabling/disabling of packages" in CURATORS.md for how to manage this section.
+    #
+    # Benchmark bounds issues
+    - IntervalMap # tried IntervalMap-0.6.2.1, but its *benchmarks* requires the disabled package: SegmentTree
+    - accelerate-fourier # tried accelerate-fourier-1.0.0.5, but its *benchmarks* requires accelerate-llvm-native >=1.1 && < 1.2 and the snapshot contains accelerate-llvm-native-1.3.0.0
+    - accelerate-fourier # tried accelerate-fourier-1.0.0.5, but its *benchmarks* requires criterion >=1.0 && < 1.5 and the snapshot contains criterion-1.6.3.0
+    - avers # tried avers-0.0.17.1, but its *benchmarks* requires criterion >=1.1.4.0 && < 1.6 and the snapshot contains criterion-1.6.3.0
+    - binary-parsers # tried binary-parsers-0.2.4.0, but its *benchmarks* requires criterion ==1.1.* and the snapshot contains criterion-1.6.3.0
+    - buffer-builder # tried buffer-builder-0.2.4.8, but its *benchmarks* requires the disabled package: json-builder
+    - cipher-aes # tried cipher-aes-0.2.11, but its *benchmarks* requires the disabled package: crypto-cipher-benchmarks
+    - cipher-camellia # tried cipher-camellia-0.0.2, but its *benchmarks* requires the disabled package: crypto-cipher-benchmarks
+    - cipher-rc4 # tried cipher-rc4-0.1.4, but its *benchmarks* requires the disabled package: crypto-cipher-benchmarks
+    - cmark-gfm # tried cmark-gfm-0.2.6, but its *benchmarks* requires the disabled package: cheapskate
+    - csg # tried csg-0.1.0.6, but its *benchmarks* requires criterion < 1.6 and the snapshot contains criterion-1.6.3.0
+    - csg # tried csg-0.1.0.6, but its *benchmarks* requires vector < 0.13 and the snapshot contains vector-0.13.1.0
+    - distributed-process # tried distributed-process-0.7.4, but its *benchmarks* requires the disabled package: network-transport-tcp
+    - ed25519 # tried ed25519-0.0.5.0, but its *benchmarks* requires criterion >=0.8 && < 1.2 and the snapshot contains criterion-1.6.3.0
+    - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: test-framework-th
+    - filepath-bytestring # tried filepath-bytestring-1.4.2.1.13, but its *benchmarks* requires filepath >=1.4.2 && < =1.4.2.1 and the snapshot contains filepath-1.4.100.4
+    - galois-field # tried galois-field-1.0.2, but its *benchmarks* requires criterion >=1.5 && < 1.6 and the snapshot contains criterion-1.6.3.0
+    - hasbolt # tried hasbolt-0.1.6.3, but its *benchmarks* requires hspec >=2.4.1 && < 2.11 and the snapshot contains hspec-2.11.7
+    - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *benchmarks* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.2.1
+    - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *benchmarks* requires criterion >=1.1 && < 1.6 and the snapshot contains criterion-1.6.3.0
+    - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *benchmarks* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
+    - hasmin # tried hasmin-1.0.3, but its *benchmarks* requires criterion >=0.11 && < 1.6 and the snapshot contains criterion-1.6.3.0
+    - hip # tried hip-1.5.6.0, but its *benchmarks* requires the disabled package: repa-algorithms
+    - hw-rankselect # tried hw-rankselect-0.13.4.1, but its *benchmarks* requires resourcet >=1.1 && < 1.3 and the snapshot contains resourcet-1.3.0
+    - lz4 # tried lz4-0.2.3.1, but its *benchmarks* requires the disabled package: snappy
+    - markup-parse # tried markup-parse-0.1.1, but its *benchmarks* requires the disabled package: html-parse
+    - min-max-pqueue # tried min-max-pqueue-0.1.0.2, but its *benchmarks* requires criterion >=1.4.1 && < 1.6 and the snapshot contains criterion-1.6.3.0
+    - minisat-solver # tried minisat-solver-0.1, but its *benchmarks* requires the disabled package: easyrender
+    - normalization-insensitive # tried normalization-insensitive-2.0.2, but its *benchmarks* requires criterion >=0.6.1 && < 1.6 and the snapshot contains criterion-1.6.3.0
+    - o-clock # tried o-clock-1.4.0, but its *benchmarks* requires the disabled package: tiempo
+    - pasta-curves # tried pasta-curves-0.0.1.0, but its *benchmarks* requires criterion >=1.5 && < 1.6 and the snapshot contains criterion-1.6.3.0
+    - pg-transact # tried pg-transact-0.3.2.0, but its *benchmarks* requires the disabled package: tmp-postgres
+    - pipes # tried pipes-4.3.16, but its *benchmarks* requires optparse-applicative >=0.12 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+    - pred-trie # tried pred-trie-0.6.1, but its *benchmarks* requires the disabled package: sets
+    - regex-applicative # tried regex-applicative-0.3.4, but its *benchmarks* requires the disabled package: parsers-megaparsec
+    - servant-auth-cookie # tried servant-auth-cookie-0.6.0.3, but its *benchmarks* requires criterion >=0.6.2.1 && < 1.4 and the snapshot contains criterion-1.6.3.0
+    - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *benchmarks* requires shelly >=1.6.8 && < 1.10 and the snapshot contains shelly-1.12.1
+    - superbuffer # tried superbuffer-0.3.1.2, but its *benchmarks* requires criterion < 1.3 and the snapshot contains criterion-1.6.3.0
+    - sv # tried sv-1.4.0.1, but its *benchmarks* requires criterion >=1.3 && < 1.6 and the snapshot contains criterion-1.6.3.0
+    - ttrie # tried ttrie-0.1.2.2, but its *benchmarks* requires the disabled package: criterion-plus
+    - ttrie # tried ttrie-0.1.2.2, but its *benchmarks* requires the disabled package: stm-stats
+    - vectortiles # tried vectortiles-1.5.1, but its *benchmarks* requires criterion >=1.1 && < 1.6 and the snapshot contains criterion-1.6.3.0
+    - xeno # tried xeno-0.6, but its *benchmarks* requires the disabled package: bytestring-mmap
+    - xxhash-ffi # tried xxhash-ffi-0.2.0.0, but its *benchmarks* requires the disabled package: xxhash
+    # End of Benchmark bounds issues
+
+# end of skipped-benchmarks
+
+
+skipped-profiling:
+    # https://github.com/nomeata/ghc-heap-view/commit/8d198eb8fbbad2ce0c4527c781659f35b8909c04#diff-8288955e209cfbead5b318a8598be9c0R10
+    - ghc-heap-view
+
+
+# Mapping from Github account holding a package to the Github users who should
+# be pinged on failure. If no value is specified here, then the owning account
+# will be pinged.
+github-users:
+    diagrams:
+        - byorgey
+        - fryguybob
+        - jeffreyrosenbluth
+        - bergey
+    yesodweb:
+        - snoyberg
+    fpco:
+        - snoyberg
+    faylang:
+        - bergmark
+    silkapp:
+        - bergmark
+        - hesselink
+    snapframework:
+        - mightybyte
+    haskell-ro:
+        - mihaimaruseac
+    elm-lang:
+        - JoeyEremondi
+    prowdsponsor:
+        - meteficha
+    analytics:
+        - ekmett
+    haskell-openal:
+        - svenpanne
+    haskell-opengl:
+        - ekmett
+        - svenpanne
+    lambdabot:
+        - DanBurton
+        - mokus0
+    haskell-game:
+        - ocharles
+    Happstack:
+        - stepcut
+    clckwrks:
+        - stepcut
+    stackbuilders:
+        - jsl
+        - sestrella
+        - CristhianMotoche
+    scotty-web:
+        - RyanGlScott
+        - xich
+    ku-fpg:
+        - RyanGlScott
+    haskell-compat:
+        - RyanGlScott
+    vivid:
+        - vivid-synth
+    midair:
+        - vivid-synth
+    nano-erl:
+        - vivid-synth
+    telegram-api:
+        - klappvisor
+    fpinsight:
+        - thierry-b
+    IxpertaSolutions:
+        - Siprj
+        - liskin
+        - trskop
+        - xkollar
+    ekmett:
+        - RyanGlScott
+    onrock-eng:
+        - donkeybonks
+    tweag:
+        - bazel-runfiles
+    network-multicast:
+        - audreyt
+    xmonad:
+        - byorgey
+        - dmwit
+        - geekosaur
+        - liskin
+        - psibi
+        - slotThe
+
+# end of github-users
+
+# begin build-tool-overrides
+#
+# Used to set a mapping from build tools to package names, ignoring the
+# metadata on Hackage itself
+
+build-tool-overrides:
+    # Ignore the cabal-install-ghc72 and cabal-install-ghc74 packages
+    cabal:
+        - cabal-install
+
+# end build-tool-overrides
+
+# Useful for checking for strict upper bounds against new versions of core
+# packages, e.g. when a new version of transformers is released
+#
+# treat-as-non-core:
+# - transformers
+
+# Give an error if the latest package version doesn't match what's
+# listed below, see:
+# https://github.com/fpco/stackage-curator/issues/25
+#
+# Example:
+# If bindings-GLFW-3.1.2.1 is the current latest version write
+# - bindings-GLFW-3.1.2.1 # Comment saying what should be done when the new version is released
+tell-me-when-its-released: []
+
+# Packages which should be hidden after registering, to avoid module name
+# conflicts. This is intended for at least two use cases:
+#
+# * Making doctests pass (https://github.com/yesodweb/wai/issues/579)
+#
+# * Allowing tools like Stack to get a mapping from module name to package name
+# for automatically installing dependencies
+hide:
+- HTF # conflicts with Test.Framework in test-framework
+- async-dejafu # https://github.com/yesodweb/wai/issues/579
+- base-compat # conflicts with base-compat-batteries, see https://github.com/fpco/stackage/issues/3607
+- base-noprelude # By design, conflicts with base
+- binary-ieee754 # conflicts with data-binary-ieee754
+- cipher-aes # Cryptonite deprecation
+- cipher-blowfish # Cryptonite deprecation
+- cipher-camellia # Cryptonite deprecation
+- cipher-des # Cryptonite deprecation
+- cipher-rc4 # Cryptonite deprecation
+- constraint # conflicts with constraints
+- control-monad-free # conflicts with Control.Monad.Free in free
+- courier # conflicts with Network.Transport in network-transport
+- crypto-api # `module Crypto.Random` conflicts with cryptonite
+- crypto-cipher-types # Cryptonite deprecation
+- crypto-numbers # Cryptonite deprecation
+- crypto-pubkey # Cryptonite deprecation
+- crypto-random # Cryptonite deprecation
+- cryptohash # Cryptonite deprecation
+- cryptohash-conduit # Cryptonite deprecation
+- cryptohash-md5 # cryptohash fork
+- cryptohash-sha1 # cryptohash fork
+- cryptohash-sha256 # cryptohash fork
+- fay-base # conflicts with many modules in base and others
+- filemanip # conflicts with System.FilePath.Glob in Glob
+- ghc-lib # per its own recommendation. conflicts with template-haskell
+- ghc-lib-parser # also conflicts with template-haskell
+- gl # conflicts with modules in OpenGLRaw
+- gtk3 # conflicts with many modules in gtk
+- hashmap # conflicts with Data.HashSet in unordered-containers
+- hledger-web # conflicts with Foundation in foundation
+- hs-functors # conflicts with profunctors, see #3609/closed
+- hxt-unicode # conflicts with Data.String.UTF8 in utf8-string
+- kawhi # conflicts with Control.Monad.Http in monad-http
+- language-c # conflicts with modules in language-c-quote
+- lenz # conflicts with lens, see https://github.com/fpco/stackage/issues/3600
+- log # conflicts with modules in its dependencies
+- matrices # conflicts with matrix
+- monad-extras # conflicts with Control.Monad.Extra in extra
+- monads-tf # mtl is preferred
+- nanospec # conflicts with Test.Hspec in hspec
+- objective # conflicts with Control.Object in natural-transformation
+- plot-gtk3 # conflicts with many modules in plot-gtk
+- pretty-class # conflicts with pretty and prettyclass
+- prettyclass # conflicts with pretty and pretty-class
+- prompt # conflicts with Control.Monad.Prompt in MonadPrompt
+- regex-compat-tdfa # conflicts with many modules in regex-compat
+- regex-pcre-builtin # conflicts with many modules in regex-pcre
+- rerebase # conflicts with base
+- svg-tree # conflicts with Graphics.Svg in svg-builder
+- temporary-rc # conflicts with temporary
+- temporary-resourcet # conflicts with temporary
+- zip # conflicts with Codec.Archive.Zip in zip-archive
+
+
+# Experimental: packages where Hackage cabal file revisions should be ignored.
+#
+# This always use the cabal file shipped with the sdist tarball instead of the latest revision.
+#
+# This only supports pinning to the initial release (revision 0), not to an arbitrary revision.
+no-revisions:
+- tls
+- mime-mail
+- basement
+- cryptonite
+- foundation
+- gauge
+- http-download
+- rio-prettyprint
+- hi-file-parser
+- aura
+
+
+# Note, this no longer actually does anything with curator2 unfortunately:
+# Do not build these packages in parallel with others. Useful for high memory
+# usage.
+non-parallel-builds:
+- amazonka-ec2 # Around 6 GB memory consumption - so do not build in parallel to optimize overall performance. For more details see: https://gitlab.haskell.org/ghc/ghc/-/issues/19203, https://github.com/brendanhay/amazonka/issues/549 and related issues.
+- pandoc
+- gogol-dfareporting
+- gogol-compute
+- idris
+- massiv-persist
+- massiv-serialise

--- a/build-constraints/lts-22-build-constraints.yaml
+++ b/build-constraints/lts-22-build-constraints.yaml
@@ -5142,7 +5142,7 @@ packages:
         - unidecode ^>= 0.1.0.4
 
     "Chris Smith <cdsmith@gmail.com>":
-        - HMock ^>= 0.5.1.2
+        - HMock < 0 # dep cycle, was ^>= 0.5.1.2
         - explainable-predicates ^>= 0.1.2.4
 
     "Tim Emiola <tim.emiola@gmail.com> @adetokunbo":

--- a/build-constraints/lts-22-build-constraints.yaml
+++ b/build-constraints/lts-22-build-constraints.yaml
@@ -8339,6 +8339,10 @@ skipped-tests:
     - tasty-expected-failure # via tasty-hedgehog
     - vector # doctest
     - vector-binary-instances
+    - horizontal-rule # HMock
+    - phatsort # HMock
+    - redact # HMock
+
 
     # TODO
     - rpmbuild-order

--- a/build-constraints/lts-22-build-constraints.yaml
+++ b/build-constraints/lts-22-build-constraints.yaml
@@ -9099,6 +9099,8 @@ expected-test-failures:
     - tasty-discover # https://github.com/commercialhaskell/stackage/issues/4722
     - threads # https://github.com/basvandijk/threads/issues/10
     - tmp-postgres # https://github.com/jfischoff/tmp-postgres/issues/1
+    - rzk
+    - sydtest
 
     # Please review the sections above before adding packages to a new section or to Misc.
 


### PR DESCRIPTION
Got a dep cycle so disabled HMock, but it's in 22.0 so maybe there's a better way to resolve this?
