### PR TITLE
Reinstate store package

### DIFF
--- a/build-constraints/lts-23-build-constraints.yaml
+++ b/build-constraints/lts-23-build-constraints.yaml
@@ -873,7 +873,7 @@ packages:
         - persistent-sqlite ^>= 2.13.3.0
         - persistent-template ^>= 2.12.0.0
         - persistent-test ^>= 2.13.1.3
-        - store < 0 # 0.7.18 https://github.com/mgsloan/store/issues/179
+        - store
         - wai-extra ^>= 3.1.16 && <3.1.17 # https://github.com/commercialhaskell/stackage/issues/7570
         - wai-websockets ^>= 3.0.1.2
         - warp-tls ^>= 3.4.9
@@ -1640,7 +1640,7 @@ packages:
         - reliable-io ^>= 0.0.2
 
     "Michael Sloan <mgsloan@gmail.com> @mgsloan":
-        - store < 0
+        - store
         - store-core ^>= 0.4.4.7
         - store-streaming < 0
         - th-orphans ^>= 0.13.16
@@ -8727,6 +8727,7 @@ expected-test-failures:
     - functor-combinators # 0.4.1.3 https://github.com/mstksg/functor-combinators/issues/9
     - errata # 0.4.0.2 against hspec-golden 0.2.2.0
     - myers-diff # 0.3.0.0
+    - store # 0.7.19 https://github.com/mgsloan/store/issues/181
 
     # Consistent test failures
     - Allure # 0.11.0.0


### PR DESCRIPTION
It is now back to Nightly (https://www.stackage.org/nightly-2024-12-21/package/store-0.7.19), so it would be great to get it back into LTS as well.

Checklist for adding a package:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention the yaml file)
- [x] Package is already added to nightly (if possible)
- [ ] On your machine, in a new directory, you have successfully run the following set of commands (replacing $package and $version with the name and version of the package you want to add to Stackage LTS):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver lts
      stack --resolver lts build --haddock --test --bench --no-run-benchmarks

or using the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package):

      verify-package $package lts
