### PR TITLE
Revives ghc-typelits-presburger and its transitive dependents

### DIFF
--- a/build-constraints/lts-23-build-constraints.yaml
+++ b/build-constraints/lts-23-build-constraints.yaml
@@ -4880,11 +4880,11 @@ packages:
 
     "Hiromi Ishii <konn.jinro@gmail.com> @konn":
         - equational-reasoning ^>= 0.7.0.3
-        - ghc-typelits-presburger < 0 # ghc-9.8.4 https://github.com/konn/ghc-typelits-presburger/issues/30
-        - singletons-presburger < 0
-        - type-natural < 0
+        - ghc-typelits-presburger ^>= 0.7.4.1
+        - singletons-presburger ^>= 0.7.4.0
+        - type-natural ^>= 1.3.0.2
         - subcategories ^>= 0.2.1.1
-        - sized < 0
+        - sized ^>= 1.1.0.2
 
     "Frank Doepper <stackage@woffs.de> @woffs":
         - amqp-utils < 0


### PR DESCRIPTION
This PR revives `ghc-typelits-presburger` in LTS 23, which once got excluded due to `getKey` incompatibility in GHC 9.8.4. All the packages are tested to be built with GHC 9.8.4 with recent LTS 23 dependencies.

Checklist for adding a package:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention the yaml file)
- [x] Package is already added to nightly (if possible)
- [x] On your machine, in a new directory, you have successfully run the following set of commands (replacing $package and $version with the name and version of the package you want to add to Stackage LTS):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver lts
      stack --resolver lts build --haddock --test --bench --no-run-benchmarks

or using the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package):

      verify-package $package lts
