### PR TITLE
Re-enable dhall

### DIFF
--- a/build-constraints/lts-23-build-constraints.yaml
+++ b/build-constraints/lts-23-build-constraints.yaml
@@ -1375,7 +1375,7 @@ packages:
         - turtle ^>= 1.6.2
         - foldl ^>= 1.4.17
         - bench < 0
-        - dhall < 0
+        - dhall
         - dhall-bash < 0
         - dhall-json < 0
         - dhall-lsp-server < 0
@@ -6640,7 +6640,6 @@ packages:
         - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.2.0
-        - dhall < 0 # tried dhall-1.42.1, but its *library* requires Diff >=0.2 && < 0.5 and the snapshot contains Diff-0.5
         - dhall-bash < 0 # tried dhall-bash-1.0.41, but its *library* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.1.0
         - dhall-bash < 0 # tried dhall-bash-1.0.41, but its *library* requires text >=0.2 && < 2.1 and the snapshot contains text-2.1.1
         - dhall-json < 0 # tried dhall-json-1.7.12, but its *library* requires aeson >=1.4.6.0 && < 2.2 and the snapshot contains aeson-2.2.3.0


### PR DESCRIPTION
Checklist for adding a package:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention the yaml file)
- [ ] Package is already added to nightly (if possible)
- [X] On your machine, in a new directory, you have successfully run the following set of commands (replacing $package and $version with the name and version of the package you want to add to Stackage LTS):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver lts
      stack --resolver lts build --haddock --test --bench --no-run-benchmarks

or using the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package):

      verify-package $package lts

Now that

* https://github.com/dhall-lang/dhall-haskell/pull/2622

is released to hackage as dhall-1.42.2, we can add dhall back to the LTS.
Sadly the other packages are not compatible yet, as far as I can see.
