### PR TITLE
Update and enable Clash

### DIFF
--- a/build-constraints/lts-23-build-constraints.yaml
+++ b/build-constraints/lts-23-build-constraints.yaml
@@ -2508,10 +2508,10 @@ packages:
         - ghc-typelits-extra ^>= 0.4.7
         - ghc-typelits-knownnat ^>= 0.7.12
         - ghc-typelits-natnormalise ^>= 0.7.10
-        - clash-prelude ^>= 1.8.1
-        - clash-lib < 0 # ghc-9.8.4 https://github.com/clash-lang/clash-compiler/issues/2852
-        - clash-ghc < 0
-        - clash-prelude-hedgehog < 0
+        - clash-prelude ^>= 1.8.2
+        - clash-lib ^>= 1.8.2
+        - clash-ghc ^>= 1.8.2
+        - clash-prelude-hedgehog ^>= 1.8.2
 
     "Martijn Bastiaan <martijn@hmbastiaan.nl> @martijnbastiaan":
         - aeson-pretty ^>= 0.8.10


### PR DESCRIPTION
Clash was [dropped from nightly-2024-12-05](https://www.stackage.org/diff/nightly-2024-12-04/nightly-2024-12-05) because it [did not compile with GHC 9.8.4](https://github.com/clash-lang/clash-compiler/issues/2852). We [got back in nightly](https://github.com/commercialhaskell/stackage/pull/7681) but if I read [this](https://www.stackage.org/blog/2024/12/announce-lts-23-nightly-ghc-9.10#:~:text=If%20your%20package%20is%20missing%20from%20LTS%2023%20and%20can%20build%20there%2C%20you%20can%20easily%20have%20it%20added%20by%20opening%20a%20PR%20in%20lts%2Dhaskell%20to%20the%20build%2Dconstraints/lts%2D23%2Dbuild%2Dconstraints.yaml%20file.) correctly, we can also come back in LTS-23, which was released before we got around to fixing the 9.8.4 issue. I hope this interpretation and this PR are correct.

The packages receive a minor version bump from 1.8.1 to 1.8.2 as that version has the necessary changes for GHC 9.8.4.

Checklist for adding a package:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention the yaml file)
- [x] Package is already added to nightly (if possible)
- [x] On your machine, in a new directory, you have successfully run the following set of commands (replacing $package and $version with the name and version of the package you want to add to Stackage LTS):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver lts
      stack --resolver lts build --haddock --test --bench --no-run-benchmarks

or using the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package):

      verify-package $package lts
