### PR TITLE
add monad-logger-syslog

### DIFF
--- a/build-constraints/lts-23-build-constraints.yaml
+++ b/build-constraints/lts-23-build-constraints.yaml
@@ -10,6 +10,9 @@ cabal-format-version: "3.0"
 
 # Constraints for brand new builds
 packages:
+    "Ernesto Hernandez-Novich <haskell@iamemhn.link>":
+        - monad-logger-syslog ^>= 0.1.6.1
+
     "Taimoor Zaeem <mtaimoorzaeem@gmail.com @taimoorzaeem":
         - aeson-jsonpath ^>= 0.2.0.0
 


### PR DESCRIPTION
Added `monad-logger-syslog` latest release 0.1.6.1 that works with LTS-23

Checklist for adding a package:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention the yaml file)
- [x] Package is already added to nightly (if possible)
- [x] On your machine, in a new directory, you have successfully run the following set of commands (replacing $package and $version with the name and version of the package you want to add to Stackage LTS):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver lts
      stack --resolver lts build --haddock --test --bench --no-run-benchmarks

or using the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package):

      verify-package $package lts
