### PR TITLE
Reenable http-api-data-qq

### DIFF
--- a/build-constraints/lts-24-build-constraints.yaml
+++ b/build-constraints/lts-24-build-constraints.yaml
@@ -6855,7 +6855,6 @@ expected-test-failures:
     - fsnotify # Often runs out of inotify handles
     - hastache
     - hedn
-    - http-api-data-qq
     - ihaskell # https://github.com/gibiansky/IHaskell/issues/551
     - kdt # 0.2.6 https://github.com/giogadi/kdt/issues/7
     - lapack


### PR DESCRIPTION
Disabled in https://github.com/commercialhaskell/lts-haskell/commit/245ff3f16c6d8afcabddf9af54e0069215457203, test was already disabled on `main`, forgot to make a release. Released 0.1.0.1 with the test skipped.

Checklist for adding a package:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention the yaml file)
- [ ] Package is already added to nightly (if possible)
- [ ] On your machine, in a new directory, you have successfully run the following set of commands (replacing $package and $version with the name and version of the package you want to add to Stackage LTS):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver lts
      stack --resolver lts build --haddock --test --bench --no-run-benchmarks

or using the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package):

      verify-package $package lts
