### PR TITLE
Update and enable Clash

### DIFF
--- a/build-constraints/lts-24-build-constraints.yaml
+++ b/build-constraints/lts-24-build-constraints.yaml
@@ -2514,10 +2514,10 @@ packages:
         - ghc-typelits-extra ^>= 0.4.8
         - ghc-typelits-knownnat ^>= 0.7.13
         - ghc-typelits-natnormalise ^>= 0.7.10 && <0.7.11
-        - clash-prelude ^>= 1.8.2
-        - clash-lib < 0 # 1.8.2 https://github.com/commercialhaskell/stackage/issues/7752
-        - clash-ghc < 0
-        - clash-prelude-hedgehog ^>= 1.8.2
+        - clash-prelude ^>= 1.8.4
+        - clash-lib ^>= 1.8.4
+        - clash-ghc ^>= 1.8.4
+        - clash-prelude-hedgehog ^>= 1.8.4
 
     "Martijn Bastiaan <martijn@hmbastiaan.nl> @martijnbastiaan":
         - aeson-pretty ^>= 0.8.10
@@ -6481,7 +6481,6 @@ skipped-tests:
     - cassava-conduit # tried cassava-conduit-0.6.6, but its *test-suite* requires text >=1.2 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1.2
     - chimera # tried chimera-0.4.1.0, but its *test-suite* requires QuickCheck >=2.10 && < 2.15 and the snapshot contains QuickCheck-2.15.0.1
     - chimera # tried chimera-0.4.1.0, but its *test-suite* requires tasty-quickcheck < 0.11 and the snapshot contains tasty-quickcheck-0.11.1
-    - clash-prelude # tried clash-prelude-1.8.2, but its *test-suite* requires doctest-parallel >=0.2 && < 0.4 and the snapshot contains doctest-parallel-0.4
     - colour # tried colour-2.3.6, but its *test-suite* requires QuickCheck >=2.5 && < 2.15 and the snapshot contains QuickCheck-2.15.0.1
     - colour # tried colour-2.3.6, but its *test-suite* requires random >=1.0 && < 1.2 and the snapshot contains random-1.2.1.3
     - configurator-pg # tried configurator-pg-0.2.10, but its *test-suite* requires filepath >=1.4 && < 1.5 and the snapshot contains filepath-1.5.4.0


### PR DESCRIPTION
Fixes issue https://github.com/commercialhaskell/stackage/issues/7752

We need the latest revisions (-r1 from 2025-12-28) of `clash-prelude` and `clash-lib` for test suites to work. Older ones don't satisfy the dependency constraints so are ineligible.

Clash is not on the current nightly because GHC 9.12 doesn't work with Clash. GHC 9.12.3 will fix that.

I locally verified the packages succesfully complete `stack build --haddock --test --bench --no-run-benchmarks` with LTS 24.26.

Checklist for adding a package:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention the yaml file)
- [ ] Package is already added to nightly (if possible)
- [ ] On your machine, in a new directory, you have successfully run the following set of commands (replacing $package and $version with the name and version of the package you want to add to Stackage LTS):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver lts
      stack --resolver lts build --haddock --test --bench --no-run-benchmarks

or using the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package):

      verify-package $package lts
