### PR TITLE
bring back dataframe with a bump

### DIFF
--- a/build-constraints/lts-24-build-constraints.yaml
+++ b/build-constraints/lts-24-build-constraints.yaml
@@ -5286,7 +5286,7 @@ packages:
         - consumers ^>= 2.3.3.1 && < 2.3.4.0
         - crdt-event-fold ^>= 1.8.1.2
         - data-prometheus ^>= 0.1.0.0
-        - dataframe ^>= 0.2.0.2 && < 0 # https://github.com/mchav/dataframe/issues/61
+        - dataframe ^>= 0.3 && < 0.3.5 # https://github.com/mchav/dataframe/issues/61
         - delta-types ^>= 1.0.0.0
         - diagrams-braille ^>= 0.1.2
         - digraph ^>= 0.3.2
@@ -5594,6 +5594,7 @@ packages:
         - gitlib < 0 # 3.1.3 https://github.com/jwiegley/gitlib/issues/112
         - gitlib-libgit2 < 0
         - gitlib-test < 0
+        - granite ^>= 0.3
         - groom ^>= 0.1.2.1
         - groups ^>= 0.5.3
         - gtk ^>= 0.15.10
@@ -5813,6 +5814,7 @@ packages:
         - smtlib-backends-tests
         - snap-core ^>= 1.0.5.1
         - snappy ^>= 0.2.0.4
+        - snappy-hs ^>= 0.1 && <0.1.1
         - some ^>= 1.0.6
         - spdx ^>= 1.1
         - special-values ^>= 0.1.0.0


### PR DESCRIPTION
`dataframe-0.2` [fell out](https://github.com/commercialhaskell/lts-haskell/commit/52da9b14e46d588b9856625a0f7f751c059bab27) of lts-24 when we moved to 9.10.3 (due to its `text` bump) - this brings back `dataframe-0.3`.

The version bump might not be ideal, but I still feel better than not shipping it at all.

Checklist for adding a package:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention the yaml file)
- [x] Package is already added to nightly (if possible)
- [ ] On your machine, in a new directory, you have successfully run the following set of commands (replacing $package and $version with the name and version of the package you want to add to Stackage LTS):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver lts
      stack --resolver lts build --haddock --test --bench --no-run-benchmarks

or using the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package):

      verify-package $package lts

_(seems a bug that github renders this with so much vertical space?)_